### PR TITLE
Make Message accept delivery_mode=None

### DIFF
--- a/aio_pika/message.py
+++ b/aio_pika/message.py
@@ -33,7 +33,7 @@ class Message:
     )
 
     def __init__(self, body: bytes, *, headers: dict = None, content_type: str = None,
-                 content_encoding: str = None, delivery_mode: DeliveryMode = DeliveryMode.NOT_PERSISTENT,
+                 content_encoding: str = None, delivery_mode: DeliveryMode = None,
                  priority: int = None, correlation_id=None,
                  reply_to: str = None, expiration: DateType = None,
                  message_id: str = None,
@@ -64,7 +64,7 @@ class Message:
         self.headers = headers
         self.content_type = content_type
         self.content_encoding = content_encoding
-        self.delivery_mode = DeliveryMode(int(delivery_mode)).value
+        self.delivery_mode = DeliveryMode(int(delivery_mode or DeliveryMode.NOT_PERSISTENT)).value
         self.priority = priority
         self.correlation_id = self._as_bytes(correlation_id)
         self.reply_to = reply_to

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -159,7 +159,6 @@ class TestCase(AsyncTestCase):
         yield from queue.delete()
         yield from wait((client.close(), client.closing), loop=self.loop)
 
-
     @pytest.mark.asyncio
     def test_incoming_message_info(self):
         client = yield from connect(AMQP_URL, loop=self.loop)

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -128,6 +128,39 @@ class TestCase(AsyncTestCase):
         yield from wait((client.close(), client.closing), loop=self.loop)
 
     @pytest.mark.asyncio
+    def test_simple_publish_and_receive_delivery_mode_explicitly_none(self):
+        client = yield from connect(AMQP_URL, loop=self.loop)
+
+        queue_name = self.get_random_name("test_connection")
+        routing_key = self.get_random_name()
+
+        channel = yield from client.channel()
+        exchange = yield from channel.declare_exchange('direct', auto_delete=True)
+        queue = yield from channel.declare_queue(queue_name, auto_delete=True)
+
+        yield from queue.bind(exchange, routing_key)
+
+        body = bytes(shortuuid.uuid(), 'utf-8')
+
+        yield from exchange.publish(
+            Message(
+                body, content_type='text/plain',
+                headers={'foo': 'bar'},
+                delivery_mode=None
+            ),
+            routing_key
+        )
+
+        incoming_message = yield from queue.get(timeout=5)
+        incoming_message.ack()
+
+        self.assertEqual(incoming_message.body, body)
+        yield from queue.unbind(exchange, routing_key)
+        yield from queue.delete()
+        yield from wait((client.close(), client.closing), loop=self.loop)
+
+
+    @pytest.mark.asyncio
     def test_incoming_message_info(self):
         client = yield from connect(AMQP_URL, loop=self.loop)
 


### PR DESCRIPTION
Make `message.Message` class to accept `None` values for `delivery_mode` keyword argument.
Relates to: #3 