### PR TITLE
Fix IOLoopAdapter

### DIFF
--- a/aio_pika/adapter.py
+++ b/aio_pika/adapter.py
@@ -9,10 +9,13 @@ LOGGER = logging.getLogger(__name__)
 
 
 class IOLoopAdapter:
-    __slots__ = 'loop',
+    __slots__ = 'loop', 'handlers', 'readers', 'writers'
 
     def __init__(self, loop: asyncio.AbstractEventLoop):
         self.loop = loop
+        self.handlers = {}
+        self.readers = set()
+        self.writers = set()
 
     def add_timeout(self, deadline, callback_method):
         return self.loop.call_later(deadline, callback_method)
@@ -22,30 +25,98 @@ class IOLoopAdapter:
         return handle.cancel()
 
     def add_handler(self, fd, cb, event_state):
+        if fd in self.handlers:
+            raise ValueError("fd {} added twice".format(fd))
+        self.handlers[fd] = cb
+
         if event_state & base_connection.BaseConnection.READ:
-            self.loop.add_reader(fd, partial(cb, fd=fd, events=base_connection.BaseConnection.READ))
+            self.loop.add_reader(
+                fd,
+                partial(
+                    cb,
+                    fd=fd,
+                    events=base_connection.BaseConnection.READ
+                )
+            )
+            self.readers.add(fd)
+
         if event_state & base_connection.BaseConnection.WRITE:
-            self.loop.add_writer(fd, partial(cb, fd=fd, events=base_connection.BaseConnection.WRITE))
+            self.loop.add_writer(
+                fd,
+                partial(
+                    cb,
+                    fd=fd,
+                    events=base_connection.BaseConnection.WRITE
+                )
+            )
+            self.writers.add(fd)
 
     def remove_handler(self, fd):
-        self.loop.remove_reader(fd)
-        self.loop.remove_writer(fd)
+        if fd not in self.handlers:
+            return
+
+        if fd in self.readers:
+            self.loop.remove_reader(fd)
+            self.readers.remove(fd)
+
+        if fd in self.writers:
+            self.loop.remove_writer(fd)
+            self.writers.remove(fd)
+
+        del self.handlers[fd]
 
     def update_handler(self, fd, event_state):
-        raise NotImplementedError()
+        if event_state & base_connection.BaseConnection.READ:
+            if fd not in self.readers:
+                self.loop.add_reader(
+                    fd,
+                    partial(
+                        self.handlers[fd],
+                        fd=fd,
+                        events=base_connection.BaseConnection.READ
+                    )
+                )
+                self.readers.add(fd)
+        else:
+            if fd in self.readers:
+                self.loop.remove_reader(fd)
+                self.readers.remove(fd)
+
+        if event_state & base_connection.BaseConnection.WRITE:
+            if fd not in self.writers:
+                self.loop.add_writer(
+                    fd,
+                    partial(
+                        self.handlers[fd],
+                        fd=fd,
+                        events=base_connection.BaseConnection.WRITE
+                    )
+                )
+                self.writers.add(fd)
+        else:
+            if fd in self.writers:
+                self.loop.remove_writer(fd)
+                self.writers.remove(fd)
 
     def start(self):
-        return True
+        if self.loop.is_running():
+            return
+
+        self.loop.run_forever()
 
     def stop(self):
-        return True
+        if self.loop.is_closed():
+            return
+
+        self.loop.stop()
 
 
 class AsyncioConnection(base_connection.BaseConnection):
 
     def __init__(self, parameters=None, on_open_callback=None,
                  on_open_error_callback=None,
-                 on_close_callback=None, loop=None):
+                 on_close_callback=None,
+                 stop_ioloop_on_close=False, loop=None):
 
         self.sleep_counter = 0
         self.loop = loop or asyncio.get_event_loop()
@@ -54,7 +125,7 @@ class AsyncioConnection(base_connection.BaseConnection):
         super().__init__(parameters, on_open_callback,
                          on_open_error_callback,
                          on_close_callback, self.ioloop,
-                         stop_ioloop_on_close=False)
+                         stop_ioloop_on_close=stop_ioloop_on_close)
 
     def _adapter_connect(self):
         error = super()._adapter_connect()


### PR DESCRIPTION
There is not implemented "update_handler" method which is critical for publishing messages with body size greater than 1 chunk.

For instance:
```python
import asyncio
from aio_pika import connect, Message

loop = asyncio.get_event_loop()

async def main():
    connection = await connect("amqp://guest:guest@rabbit/", loop=loop)
    channel = await connection.channel()
    body = b'test' * 99999
    message = Message(body)
    await channel.default_exchange.publish(message, routing_key='')
    await connection.close()

loop.run_until_complete(main())
```

```
$ python rabbitmq.py 
Failed to send data to client. Conection unexpected closed.
Traceback (most recent call last):
  File "/tmp/venv/lib/python3.6/site-packages/aio_pika/channel.py", line 162, in _publish
    self.__channel.basic_publish(queue_name, routing_key, body, properties, mandatory, immediate)
  File "/tmp/venv/lib/python3.6/site-packages/pika/channel.py", line 338, in basic_publish
    (properties, body))
  File "/tmp/venv/lib/python3.6/site-packages/pika/channel.py", line 1150, in _send_method
    self.connection._send_method(self.channel_number, method_frame, content)
  File "/tmp/venv/lib/python3.6/site-packages/pika/connection.py", line 1571, in _send_method
    self._send_message(channel_number, method_frame, content)
  File "/tmp/venv/lib/python3.6/site-packages/pika/connection.py", line 1601, in _send_message
    self._flush_outbound()
  File "/tmp/venv/lib/python3.6/site-packages/pika/adapters/base_connection.py", line 283, in _flush_outbound
    self._manage_event_state()
  File "/tmp/venv/lib/python3.6/site-packages/pika/adapters/base_connection.py", line 478, in _manage_event_state
    self.event_state)
  File "/tmp/venv/lib/python3.6/site-packages/aio_pika/adapter.py", line 35, in update_handler
    raise NotImplementedError()
NotImplementedError
Channel <pika.channel.Channel object at 0x7f496cfdada0> closed: -1 - 
Traceback (most recent call last):
  File "/tmp/venv/lib/python3.6/site-packages/aio_pika/channel.py", line 162, in _publish
    self.__channel.basic_publish(queue_name, routing_key, body, properties, mandatory, immediate)
  File "/tmp/venv/lib/python3.6/site-packages/pika/channel.py", line 338, in basic_publish
    (properties, body))
  File "/tmp/venv/lib/python3.6/site-packages/pika/channel.py", line 1150, in _send_method
    self.connection._send_method(self.channel_number, method_frame, content)
  File "/tmp/venv/lib/python3.6/site-packages/pika/connection.py", line 1571, in _send_method
    self._send_message(channel_number, method_frame, content)
  File "/tmp/venv/lib/python3.6/site-packages/pika/connection.py", line 1601, in _send_message
    self._flush_outbound()
  File "/tmp/venv/lib/python3.6/site-packages/pika/adapters/base_connection.py", line 283, in _flush_outbound
    self._manage_event_state()
  File "/tmp/venv/lib/python3.6/site-packages/pika/adapters/base_connection.py", line 478, in _manage_event_state
    self.event_state)
  File "/tmp/venv/lib/python3.6/site-packages/aio_pika/adapter.py", line 35, in update_handler
    raise NotImplementedError()
NotImplementedError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "e.py", line 15, in <module>
    loop.run_until_complete(main())
  File "/usr/local/lib/python3.6/asyncio/base_events.py", line 466, in run_until_complete
    return future.result()
  File "e.py", line 12, in main
    await channel.default_exchange.publish(message, routing_key='')
  File "/tmp/venv/lib/python3.6/site-packages/aio_pika/exchange.py", line 157, in publish
    immediate=immediate
  File "/tmp/venv/lib/python3.6/site-packages/aio_pika/channel.py", line 166, in _publish
    self.__connection.close(reply_code=500, reply_text="Incorrect state")
TypeError: close() got an unexpected keyword argument 'reply_code'
```

Essential changes were taken from https://github.com/pika/pika/pull/805 (thanks to @zyp).