### PR TITLE
Fix channel close callback

### DIFF
--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -66,7 +66,6 @@ class Channel(BaseChannel):
         log.error("Channel %r closed: %d - %s", channel, code, reason)
 
         self._futures.reject_all(exc)
-        self._closing.set_exception(exc)
 
     def _on_return(self, channel, message, properties, body):
         msg = ReturnedMessage(channel=channel, body=body, envelope=message, properties=properties)


### PR DESCRIPTION
I think it concerns #24 as in case of closing channel there can be raised InvalidStateError on removed string.