### PR TITLE
Reconnection callback and interval

### DIFF
--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -228,7 +228,7 @@ def connect(url: str=None, *, host: str='localhost',
         port = url.port or port
         login = url.user or login
         password = url.password or password
-        virtualhost = url.path[1:] if url.path else virtualhost
+        virtualhost = url.path[1:] if len(url.path) > 1 else virtualhost
 
     connection = connection_class(
         host=host, port=port, login=login, password=password,

--- a/aio_pika/robust_channel.py
+++ b/aio_pika/robust_channel.py
@@ -47,6 +47,7 @@ class RobustChannel(Channel):
         self._queues = dict()
         self._qos = 0, 0
 
+    @asyncio.coroutine
     def on_reconnect(self, connection, channel_number):
         exc = ConnectionError('Auto Reconnect Error')
 
@@ -58,17 +59,13 @@ class RobustChannel(Channel):
         self._connection = connection
         self._channel_number = channel_number
 
-        @asyncio.coroutine
-        def _reconnect():
-            yield from self.initialize()
+        yield from self.initialize()
 
-            for name, exchange in self._exchanges.items():
-                yield from exchange.on_reconnect(self)
+        for name, exchange in self._exchanges.items():
+            yield from exchange.on_reconnect(self)
 
-            for name, queue in self._queues.items():
-                yield from queue.on_reconnect(self)
-
-        self.loop.create_task(_reconnect())
+        for name, queue in self._queues.items():
+            yield from queue.on_reconnect(self)
 
     @asyncio.coroutine
     def initialize(self, timeout=None):

--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -26,12 +26,15 @@ def _ensure_connection(func):
 class RobustConnection(Connection):
     """ Connection abstraction """
 
-    RECONNECT_INTERVAL = 1
+    DEFAULT_RECONNECT_INTERVAL = 1
     CHANNEL_CLASS = RobustChannel
 
     def __init__(self, host: str = 'localhost', port: int = 5672, login: str = 'guest',
                  password: str = 'guest', virtual_host: str = '/',
                  ssl: bool = False, *, loop=None, **kwargs):
+
+        self.reconnect_interval = kwargs.pop('reconnect_interval',
+                                             self.DEFAULT_RECONNECT_INTERVAL)
 
         super().__init__(host=host, port=port, login=login, password=password,
                          virtual_host=virtual_host, ssl=ssl, loop=loop, **kwargs)
@@ -72,7 +75,7 @@ class RobustConnection(Connection):
             future.set_result(None)
 
         self.loop.call_later(
-            self.RECONNECT_INTERVAL,
+            self.reconnect_interval,
             lambda: self.loop.create_task(self.connect())
         )
 

--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -80,7 +80,7 @@ class RobustConnection(Connection):
         )
 
     @asyncio.coroutine
-    def connect(self, callback=None):
+    def connect(self):
         result = yield from super().connect()
 
         for number, channel in self._channels.items():
@@ -103,10 +103,11 @@ class RobustConnection(Connection):
         """ Close AMQP connection """
         self._closed = True
 
-        while self._on_close_callbacks:
-            self._on_close_callbacks.pop()(self)
-
-        yield from super().close()
+        try:
+            while self._on_close_callbacks:
+                self._on_close_callbacks.pop()(self)
+        finally:
+            yield from super().close()
 
 
 connect_robust = partial(connect, connection_class=RobustConnection)


### PR DESCRIPTION
# Rationale
It's useful to have some functional to run something that should be started after the connection established and all objects (channels, queues, exchanges, etc.) were declared in case it was after reconnect.

For instance, when I've had connected, opened channel and declared some queue, I must be sure that my queue is ready and I can use it. So after reconnect this initialization should be run too.

And, of course, reconnection interval as a handy parameter was added :)