### PR TITLE
add the x-consistent-hash exchange type

### DIFF
--- a/aio_pika/exchange.py
+++ b/aio_pika/exchange.py
@@ -18,6 +18,7 @@ class ExchangeType(Enum):
     TOPIC = 'topic'
     HEADERS = 'headers'
     X_DELAYED_MESSAGE = 'x-delayed-message'
+    X_CONSISTENT_HASH = 'x-consistent-hash'
 
 
 class Exchange(BaseChannel):


### PR DESCRIPTION
RabbitMQ's consistent hash plugin is officially supported and included in the standard distribution. https://github.com/rabbitmq/rabbitmq-consistent-hash-exchange

However, because it's currently missing from the ExchangeType enum, it's awkward to declare such an exchange with with aio-pika. The fix is straightforward.