### PR TITLE
Do not attempt to reconnect channels if there is no connection

### DIFF
--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -94,10 +94,10 @@ class RobustConnection(Connection):
     def connect(self):
         result = yield from super().connect()
 
-        for number, channel in self._channels.items():
-            yield from channel.on_reconnect(self, number)
-
         if self._connection:
+            for number, channel in self._channels.items():
+                yield from channel.on_reconnect(self, number)
+
             for callback in self._on_reconnect_callbacks:
                 callback(self)
 


### PR DESCRIPTION
This seems to fix `AttributeError("'NoneType' object has no attribute 'channel'",)` mentioned in #75.

Would like to add a test to `test_amqp_robust.py` but given that the tests run against a real RabbitMQ server I'm not sure how to synchronise a server restart or similar in the context of a test.