### PR TITLE
Allow to disable robustness of exchange or queue

### DIFF
--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -220,7 +220,7 @@ class Channel(BaseChannel):
             except (AttributeError, RuntimeError) as exc:
                 log.exception("Failed to send data to client (connection unexpectedly closed)")
                 self._on_channel_close(self._channel, -1, exc)
-                self._connection.close(reply_code=500, reply_text="Incorrect state")
+                self._connection._connection.close(reply_code=500, reply_text="Incorrect state")
             else:
                 if self._publisher_confirms:
                     self._confirmations[self._delivery_tag] = f

--- a/aio_pika/robust_channel.py
+++ b/aio_pika/robust_channel.py
@@ -111,7 +111,8 @@ class RobustChannel(Channel):
     def declare_exchange(self, name: str, type: ExchangeType = ExchangeType.DIRECT,
                          durable: bool = None, auto_delete: bool = False,
                          internal: bool = False, passive: bool = False,
-                         arguments: dict = None, timeout: int = None, robust: bool = True) -> Generator[Any, None, Exchange]:
+                         arguments: dict = None, timeout: int = None,
+                         robust: bool = True) -> Generator[Any, None, Exchange]:
 
         exchange = yield from super().declare_exchange(
             name=name, type=type, durable=durable, auto_delete=auto_delete,
@@ -138,7 +139,8 @@ class RobustChannel(Channel):
     @asyncio.coroutine
     def declare_queue(self, name: str = None, *, durable: bool = None, exclusive: bool = False,
                       passive: bool = False, auto_delete: bool = False,
-                      arguments: dict = None, timeout: int = None, robust: bool = True) -> Generator[Any, None, Queue]:
+                      arguments: dict = None, timeout: int = None,
+                      robust: bool = True) -> Generator[Any, None, Queue]:
 
         queue = yield from super().declare_queue(
             name=name, durable=durable, exclusive=exclusive,

--- a/aio_pika/robust_channel.py
+++ b/aio_pika/robust_channel.py
@@ -63,10 +63,10 @@ class RobustChannel(Channel):
 
         yield from self.initialize()
 
-        for name, exchange in self._exchanges.items():
+        for exchange in self._exchanges.values():
             yield from exchange.on_reconnect(self)
 
-        for name, queue in self._queues.items():
+        for queue in self._queues.values():
             yield from queue.on_reconnect(self)
 
     @asyncio.coroutine
@@ -111,7 +111,7 @@ class RobustChannel(Channel):
     def declare_exchange(self, name: str, type: ExchangeType = ExchangeType.DIRECT,
                          durable: bool = None, auto_delete: bool = False,
                          internal: bool = False, passive: bool = False,
-                         arguments: dict = None, timeout: int = None) -> Generator[Any, None, Exchange]:
+                         arguments: dict = None, timeout: int = None, robust: bool = True) -> Generator[Any, None, Exchange]:
 
         exchange = yield from super().declare_exchange(
             name=name, type=type, durable=durable, auto_delete=auto_delete,
@@ -119,7 +119,7 @@ class RobustChannel(Channel):
             timeout=timeout,
         )
 
-        if not internal:
+        if not internal and robust:
             self._exchanges[name] = exchange
 
         return exchange
@@ -138,7 +138,7 @@ class RobustChannel(Channel):
     @asyncio.coroutine
     def declare_queue(self, name: str = None, *, durable: bool = None, exclusive: bool = False,
                       passive: bool = False, auto_delete: bool = False,
-                      arguments: dict = None, timeout: int = None) -> Generator[Any, None, Queue]:
+                      arguments: dict = None, timeout: int = None, robust: bool = True) -> Generator[Any, None, Queue]:
 
         queue = yield from super().declare_queue(
             name=name, durable=durable, exclusive=exclusive,
@@ -146,7 +146,8 @@ class RobustChannel(Channel):
             arguments=arguments, timeout=timeout,
         )
 
-        self._queues[name] = queue
+        if robust:
+            self._queues[name] = queue
 
         return queue
 

--- a/aio_pika/robust_queue.py
+++ b/aio_pika/robust_queue.py
@@ -6,10 +6,9 @@ from typing import Any, Generator
 
 import shortuuid
 
-from .exchange import Exchange
 from .common import FutureStore
 from .channel import Channel
-from .queue import Queue
+from .queue import ExchangeType, Queue
 
 log = getLogger(__name__)
 
@@ -43,7 +42,7 @@ class RobustQueue(Queue):
             yield from self.consume(consumer_tag=consumer_tag, **kwargs)
 
     @asyncio.coroutine
-    def bind(self, exchange: Exchange, routing_key: str=None, *, arguments=None, timeout: int = None):
+    def bind(self, exchange: ExchangeType, routing_key: str=None, *, arguments=None, timeout: int = None):
         kwargs = dict(arguments=arguments, timeout=timeout)
 
         result = yield from super().bind(
@@ -57,7 +56,7 @@ class RobustQueue(Queue):
         return result
 
     @asyncio.coroutine
-    def unbind(self, exchange: Exchange, routing_key: str, arguments: dict = None, timeout: int = None):
+    def unbind(self, exchange: ExchangeType, routing_key: str, arguments: dict = None, timeout: int = None):
         result = yield from super().unbind(exchange, routing_key, arguments, timeout)
         self._bindings.pop((exchange, routing_key), None)
 

--- a/aio_pika/robust_queue.py
+++ b/aio_pika/robust_queue.py
@@ -8,7 +8,7 @@ import shortuuid
 
 from .common import FutureStore
 from .channel import Channel
-from .queue import ExchangeType, Queue
+from .queue import ExchangeType_, Queue
 
 log = getLogger(__name__)
 
@@ -42,7 +42,7 @@ class RobustQueue(Queue):
             yield from self.consume(consumer_tag=consumer_tag, **kwargs)
 
     @asyncio.coroutine
-    def bind(self, exchange: ExchangeType, routing_key: str=None, *, arguments=None, timeout: int = None):
+    def bind(self, exchange: ExchangeType_, routing_key: str=None, *, arguments=None, timeout: int = None):
         kwargs = dict(arguments=arguments, timeout=timeout)
 
         result = yield from super().bind(
@@ -56,7 +56,7 @@ class RobustQueue(Queue):
         return result
 
     @asyncio.coroutine
-    def unbind(self, exchange: ExchangeType, routing_key: str, arguments: dict = None, timeout: int = None):
+    def unbind(self, exchange: ExchangeType_, routing_key: str, arguments: dict = None, timeout: int = None):
         result = yield from super().unbind(exchange, routing_key, arguments, timeout)
         self._bindings.pop((exchange, routing_key), None)
 


### PR DESCRIPTION
Within the implementation of my worker class I use robust connection and declare exclusive queue. The queue must be really exclusive within all the worker instances and I correctly handle resource locks for this queue when connecting to the server. But I can't do that when reconnecting because of preliminary repeated declaration of this queue by the `RobustChannel.on_reconnect` implementation. So I suggest to add `robust` parameter for `RobustChannel.declare_exchange` and `RobustChannel.declare_queue` methods to allow disabling robustness of exchange or queue. With this parameters user can customize repeated declaration of any exchange or queue by specific algorithm using reconnect callbacks.