### PR TITLE
Fixed auto-naming for instances of RobustQueue

### DIFF
--- a/aio_pika/robust_queue.py
+++ b/aio_pika/robust_queue.py
@@ -4,8 +4,6 @@ from logging import getLogger
 from types import FunctionType
 from typing import Any, Generator
 
-import shortuuid
-
 from .exchange import Exchange
 from .common import FutureStore
 from .channel import Channel
@@ -22,7 +20,7 @@ class RobustQueue(Queue):
     def __init__(self, loop: asyncio.AbstractEventLoop, future_store: FutureStore, channel: Channel,
                  name, durable, exclusive, auto_delete, arguments):
 
-        super().__init__(loop, future_store, channel, name or "amq_%s" % shortuuid.uuid(),
+        super().__init__(loop, future_store, channel, name,
                          durable, exclusive, auto_delete, arguments)
 
         self._consumers = {}

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,6 @@ setup(
     ],
     packages=find_packages(exclude=['tests']),
     install_requires=[
-        'shortuuid',
         'pika<0.11',
         'yarl',
     ],
@@ -49,6 +48,7 @@ setup(
             'pytest',
             'pytest-asyncio<0.6',
             'pytest-cov',
+            'shortuuid',
             'sphinx',
             'sphinx-autobuild',
             'timeout-decorator',


### PR DESCRIPTION
I'm not sure why this behavior was introduced but it breaks clients that connect to a RabbitMQ server and want to use server-generated queue name.