### PR TITLE
Ignoring authentication errors within robust connection

### DIFF
--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -80,7 +80,7 @@ class Channel(BaseChannel):
         return self._channel.channel_number
 
     def __str__(self):
-        return "{0}".format(self.number if self._channel else "Not initialized chanel")
+        return "{0}".format(self.number if self._channel else "Not initialized channel")
 
     def __repr__(self):
         return '<%s "%s#%s">' % (self.__class__.__name__, self._connection, self)

--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -351,4 +351,4 @@ def connect(url: str=None, *, host: str='localhost',
     return connection
 
 
-__all__ = ('connect', 'connect_url', 'Connection')
+__all__ = 'connect', 'Connection'

--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -4,6 +4,7 @@ from logging import getLogger
 from typing import Callable, Generator, Any
 
 from .adapter import AsyncioConnection
+from .exceptions import ProbableAuthenticationError
 from .connection import Connection, connect
 from .robust_channel import RobustChannel
 
@@ -72,6 +73,9 @@ class RobustConnection(Connection):
 
         if self._closed:
             return super()._on_connection_lost(future, connection, code, reason)
+
+        if isinstance(reason, ProbableAuthenticationError):
+            log.error("Authentication error: %d - %s", code, reason)
 
         if not future.done():
             future.set_result(None)

--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -4,7 +4,6 @@ from logging import getLogger
 from typing import Callable, Generator, Any
 
 from .adapter import AsyncioConnection
-from .exceptions import ProbableAuthenticationError
 from .connection import Connection, connect
 from .robust_channel import RobustChannel
 
@@ -73,14 +72,6 @@ class RobustConnection(Connection):
 
         if self._closed:
             return super()._on_connection_lost(future, connection, code, reason)
-
-        if isinstance(reason, ProbableAuthenticationError):
-            if not future.done():
-                future.set_exception(reason)
-
-            self.loop.create_task(self.close())
-
-            return
 
         if not future.done():
             future.set_result(None)

--- a/aio_pika/robust_queue.py
+++ b/aio_pika/robust_queue.py
@@ -1,5 +1,4 @@
 import asyncio
-from collections import namedtuple
 from logging import getLogger
 from types import FunctionType
 from typing import Any, Generator
@@ -8,13 +7,9 @@ import shortuuid
 
 from .common import FutureStore
 from .channel import Channel
-from .queue import ExchangeType_, Queue
+from .queue import ConsumerTag, ExchangeType_, Queue
 
 log = getLogger(__name__)
-
-
-ConsumerTag = str
-DeclarationResult = namedtuple('DeclarationResult', ('message_count', 'consumer_count'))
 
 
 class RobustQueue(Queue):
@@ -38,7 +33,7 @@ class RobustQueue(Queue):
             exchange, routing_key = item
             yield from self.bind(exchange, routing_key, **kwargs)
 
-        for consumer_tag, kwargs in tuple(self._consumers.items()):
+        for consumer_tag, kwargs in self._consumers.items():
             yield from self.consume(consumer_tag=consumer_tag, **kwargs)
 
     @asyncio.coroutine


### PR DESCRIPTION
I suggest not to raise `pika.exceptions.ProbableAuthenticationError` within robust connection and continue retrying to connect.