### PR TITLE
Use latest version of Pika

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'shortuuid',
-        'pika<0.11',
+        'pika',
         'yarl',
     ],
     python_requires=">3.4.*, <4",

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -16,7 +16,7 @@ import aio_pika
 import aio_pika.exceptions
 from copy import copy
 from aio_pika import connect, Message, DeliveryMode
-from aio_pika.exceptions import ProbableAuthenticationError, MessageProcessError
+from aio_pika.exceptions import MessageProcessError
 from aio_pika.exchange import ExchangeType
 from aio_pika.tools import wait
 from unittest import mock
@@ -764,7 +764,7 @@ class TestCase(BaseTestCase):
     def test_wrong_credentials(self):
         amqp_url = AMQP_URL.with_user(uuid.uuid4().hex).with_password(uuid.uuid4().hex)
 
-        with self.assertRaises(ProbableAuthenticationError):
+        with self.assertRaises(ConnectionRefusedError):
             yield from connect(
                 amqp_url,
                 loop=self.loop


### PR DESCRIPTION
I don't really understand why `ProbableAuthenticationError` is no longer being raised, though.

See #54, #80 and pika/pika#875