### PR TITLE
Downgrade pika to 0.10.0

### DIFF
--- a/aio_pika/adapter.py
+++ b/aio_pika/adapter.py
@@ -2,34 +2,161 @@ import asyncio
 import logging
 import platform
 from contextlib import contextmanager
+from functools import partial
 
-from pika.adapters import asyncio_connection
+from pika.adapters import base_connection
 from pika import channel
 
 from .version import __version__
 
 
-LOGGER = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 PRODUCT = 'aio-pika'
 
 
-class AsyncioConnection(asyncio_connection.AsyncioConnection):
+class IOLoopAdapter:
+    __slots__ = 'loop', 'handlers', 'readers', 'writers'
+
+    def __init__(self, loop: asyncio.AbstractEventLoop):
+        self.loop = loop
+        self.handlers = {}
+        self.readers = set()
+        self.writers = set()
+
+    def add_timeout(self, deadline, callback_method):
+        return self.loop.call_later(deadline, callback_method)
+
+    @staticmethod
+    def remove_timeout(handle: asyncio.Handle):
+        return handle.cancel()
+
+    def add_handler(self, fd, cb, event_state):
+        if fd in self.handlers:
+            raise ValueError("fd {} added twice".format(fd))
+        self.handlers[fd] = cb
+
+        if event_state & base_connection.BaseConnection.READ:
+            self.loop.add_reader(
+                fd,
+                partial(
+                    cb,
+                    fd=fd,
+                    events=base_connection.BaseConnection.READ
+                )
+            )
+            self.readers.add(fd)
+
+        if event_state & base_connection.BaseConnection.WRITE:
+            self.loop.add_writer(
+                fd,
+                partial(
+                    cb,
+                    fd=fd,
+                    events=base_connection.BaseConnection.WRITE
+                )
+            )
+            self.writers.add(fd)
+
+    def remove_handler(self, fd):
+        if fd not in self.handlers:
+            return
+
+        if fd in self.readers:
+            self.loop.remove_reader(fd)
+            self.readers.remove(fd)
+
+        if fd in self.writers:
+            self.loop.remove_writer(fd)
+            self.writers.remove(fd)
+
+        del self.handlers[fd]
+
+    def update_handler(self, fd, event_state):
+        if event_state & base_connection.BaseConnection.READ:
+            if fd not in self.readers:
+                self.loop.add_reader(
+                    fd,
+                    partial(
+                        self.handlers[fd],
+                        fd=fd,
+                        events=base_connection.BaseConnection.READ
+                    )
+                )
+                self.readers.add(fd)
+        else:
+            if fd in self.readers:
+                self.loop.remove_reader(fd)
+                self.readers.remove(fd)
+
+        if event_state & base_connection.BaseConnection.WRITE:
+            if fd not in self.writers:
+                self.loop.add_writer(
+                    fd,
+                    partial(
+                        self.handlers[fd],
+                        fd=fd,
+                        events=base_connection.BaseConnection.WRITE
+                    )
+                )
+                self.writers.add(fd)
+        else:
+            if fd in self.writers:
+                self.loop.remove_writer(fd)
+                self.writers.remove(fd)
+
+    def start(self):
+        if self.loop.is_running():
+            return
+
+        self.loop.run_forever()
+
+    def stop(self):
+        if self.loop.is_closed():
+            return
+
+        self.loop.stop()
+
+
+class AsyncioConnection(base_connection.BaseConnection):
 
     def __init__(self, parameters=None, on_open_callback=None,
-                 on_open_error_callback=None, on_close_callback=None,
-                 stop_ioloop_on_close=False, loop: asyncio.AbstractEventLoop=None):
+                 on_open_error_callback=None,
+                 on_close_callback=None,
+                 stop_ioloop_on_close=False, loop=None):
 
-        super().__init__(
-            parameters=parameters,
-            on_open_callback=on_open_callback,
-            on_open_error_callback=on_open_error_callback,
-            on_close_callback=on_close_callback,
-            stop_ioloop_on_close=stop_ioloop_on_close,
-            custom_ioloop=loop,
-        )
-
+        self.sleep_counter = 0
+        self.loop = loop or asyncio.get_event_loop()
+        self.ioloop = IOLoopAdapter(self.loop)
         self.channel_cleanup_callback = None
+
+        super().__init__(parameters, on_open_callback,
+                         on_open_error_callback,
+                         on_close_callback, self.ioloop,
+                         stop_ioloop_on_close=stop_ioloop_on_close)
+
+    def _adapter_connect(self):
+        error = super()._adapter_connect()
+
+        if not error:
+            self.ioloop.add_handler(
+                self.socket.fileno(), self._handle_events, self.event_state
+            )
+
+        return error
+
+    def _adapter_disconnect(self):
+        if self.socket:
+            self.ioloop.remove_handler(self.socket.fileno())
+
+        super()._adapter_disconnect()
+
+    def _handle_disconnect(self):
+        try:
+            super()._handle_disconnect()
+            super()._handle_write()
+        except Exception as e:
+            self._on_disconnect(-1, e)
 
     @property
     def _client_properties(self) -> dict:
@@ -56,7 +183,7 @@ class AsyncioConnection(asyncio_connection.AsyncioConnection):
             super()._on_channel_cleanup(channel)
 
     def _create_channel(self, channel_number, on_open_callback):
-        LOGGER.debug('Creating channel %s', channel_number)
+        log.debug('Creating channel %s', channel_number)
         return Channel(self, channel_number, on_open_callback)
 
 
@@ -100,7 +227,7 @@ class Channel(channel.Channel):
         if self._on_getempty_callback:
             self._on_getempty_callback(method_frame)
         else:
-            LOGGER.debug("Unexcpected getempty frame %r", method_frame)
+            log.debug("Unexpected getempty frame %r", method_frame)
 
         super()._on_getempty(method_frame)
 

--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -17,8 +17,6 @@ from .adapter import AsyncioConnection
 
 
 log = logging.getLogger(__name__)
-pika_logger = logging.getLogger('pika.adapters.base_connection')
-pika_logger.setLevel(logging.WARNING)
 
 
 def _ensure_connection(func):

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'shortuuid',
-        'pika>=0.11,<0.12',
+        'pika==0.10.0',
         'yarl',
     ],
     python_requires=">3.4.*, <4",

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -16,7 +16,7 @@ import aio_pika
 import aio_pika.exceptions
 from copy import copy
 from aio_pika import connect, Message, DeliveryMode
-from aio_pika.exceptions import MessageProcessError
+from aio_pika.exceptions import MessageProcessError, ProbableAuthenticationError
 from aio_pika.exchange import ExchangeType
 from aio_pika.tools import wait
 from unittest import mock
@@ -764,7 +764,7 @@ class TestCase(BaseTestCase):
     def test_wrong_credentials(self):
         amqp_url = AMQP_URL.with_user(uuid.uuid4().hex).with_password(uuid.uuid4().hex)
 
-        with self.assertRaises(ConnectionRefusedError):
+        with self.assertRaises(ProbableAuthenticationError):
             yield from connect(
                 amqp_url,
                 loop=self.loop


### PR DESCRIPTION
I don't know why, but pika >= 0.11.0 breaks robust connection (and maybe something else): #112.

**How to reproduce**

Checkout this branch, start simple consumer from [example](https://aio-pika.readthedocs.io/en/latest/quick-start.html#simple-consumer) and restart RabbitMQ. Everything should be OK. Then change pika's version from 0.10.0 to 0.11.0 and repeat: there will be a lot of errors.

So I suggest to downgrade pika's version to 0.10.0 now. Here I also removed usage of pika's asyncio adapter as pika==0.10.0 doesn't have it.

But maybe (I hope that) @mosquito or @lukebakken can resolve the issue and we wouldn't have to downgrade pika.