### PR TITLE
declare_exchange in channel now timeout parameter to exchange.declare

### DIFF
--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -195,7 +195,7 @@ class Channel(BaseChannel):
                 future_store=self._futures.get_child(),
             )
 
-            yield from exchange.declare()
+            yield from exchange.declare(timeout=timeout)
 
             log.debug("Exchange declared %r", exchange)
 


### PR DESCRIPTION
The timeout value for channel.declare_exchange(timeout) wasn't passed along to `yield from exchange.declare()`