### PR TITLE
making QueueEmpty exception public

### DIFF
--- a/aio_pika/exceptions.py
+++ b/aio_pika/exceptions.py
@@ -50,6 +50,7 @@ __all__ = (
     'ProbableAuthenticationError',
     'ProtocolSyntaxError',
     'ProtocolVersionMismatch',
+    'QueueEmpty',
     'RecursionError',
     'ShortStringTooLong',
     'TransactionClosed',


### PR DESCRIPTION
Hi. I'd like to use this exception and avoid the "protected member access" warning in IDEA. I think it is quite a public one.