### PR TITLE
Handle coroutine wrapping for Python 3.4

### DIFF
--- a/aio_pika/patterns/master.py
+++ b/aio_pika/patterns/master.py
@@ -110,10 +110,14 @@ class Master(Base):
         """ Creates a new :class:`Worker` instance. """
         queue = yield from self.channel.declare_queue(channel_name, **kwargs)
 
+        if hasattr(func, "_is_coroutine"):
+            fn = func
+        else:
+            fn = asyncio.coroutine(func)
         consumer_tag = yield from queue.consume(
             partial(
                 self.on_message,
-                asyncio.coroutine(func)
+                fn
             )
         )
 

--- a/tests/test_master.py
+++ b/tests/test_master.py
@@ -30,6 +30,29 @@ class TestCase(BaseTestCase):
         yield from worker.close()
 
     @pytest.mark.asyncio
+    def test_simple_coro(self):
+        channel = yield from self.create_channel()
+        master = Master(channel)
+
+        self.state = []
+
+        @asyncio.coroutine
+        def worker_func(*, foo, bar):
+            self.state.append((foo, bar))
+
+        worker = yield from master.create_worker(
+            'worker.foo', worker_func, auto_delete=True
+        )
+
+        yield from master.proxy.worker.foo(foo=1, bar=2)
+
+        yield from asyncio.sleep(0.5, loop=self.loop)
+
+        self.assertSequenceEqual(self.state, [(1, 2)])
+
+        yield from worker.close()
+
+    @pytest.mark.asyncio
     def test_simple_many(self):
         channel = yield from self.create_channel()
         master = Master(channel)


### PR DESCRIPTION
Without this fix, you probably get the following error in Python 3.4:
```AttributeError: 'method' object has no attribute '_is_coroutine'```