### PR TITLE
Fixed ChannelClosed exception was never retrieved

### DIFF
--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -261,7 +261,6 @@ class Channel(BaseChannel):
             yield from queue.declare(timeout, passive=passive)
             return queue
 
-    @BaseChannel._ensure_channel_is_open
     @asyncio.coroutine
     def close(self) -> None:
         if not self._channel:


### PR DESCRIPTION
Related to [this issue][https://github.com/mosquito/aio-pika/issues/121].