### PR TITLE
prevent set_results on cancelled future

### DIFF
--- a/aio_pika/queue.py
+++ b/aio_pika/queue.py
@@ -248,7 +248,7 @@ class Queue(BaseChannel):
         def _on_getempty(method_frame, *a, **kw):
             if fail:
                 f.set_exception(QueueEmpty(method_frame))
-            else:
+            elif not f.cancelled():
                 f.set_result(None)
 
         def _on_getok(channel, envelope, props, body):


### PR DESCRIPTION
Sometimes when I close connection I get this error logs:

```
2018-06-13 01:07:23 ERROR Calling <bound method Channel._on_getempty of <aio_pika.adapter.Channel object at 0x10f6e3cc0>> for "1:Basic.GetEmpty" failed
Traceback (most recent call last):
  File "/Users/roman/virtualenvs/messaging2/lib/python3.6/site-packages/pika/callback.py", line 236, in process
    callback(*args, **keywords)
  File "/Users/roman/virtualenvs/messaging2/src/aio-pika/aio_pika/adapter.py", line 235, in _on_getempty
    self._on_getempty_callback(method_frame)
  File "/Users/roman/virtualenvs/messaging2/src/aio-pika/aio_pika/queue.py", line 252, in _on_getempty
    f.set_result(None)
asyncio.base_futures.InvalidStateError: invalid state
2018-06-13 01:07:23 ERROR Exception in callback BaseConnection._handle_events(fd=16, events=1)()
handle: <Handle BaseConnection._handle_events(fd=16, events=1)()>
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.6.4_4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/events.py", line 145, in _run
    self._callback(*self._args)
  File "/Users/roman/virtualenvs/messaging2/lib/python3.6/site-packages/pika/adapters/base_connection.py", line 364, in _handle_events
    self._handle_read()
  File "/Users/roman/virtualenvs/messaging2/lib/python3.6/site-packages/pika/adapters/base_connection.py", line 415, in _handle_read
    self._on_data_available(data)
  File "/Users/roman/virtualenvs/messaging2/lib/python3.6/site-packages/pika/connection.py", line 1347, in _on_data_available
    self._process_frame(frame_value)
  File "/Users/roman/virtualenvs/messaging2/lib/python3.6/site-packages/pika/connection.py", line 1414, in _process_frame
    if self._process_callbacks(frame_value):
  File "/Users/roman/virtualenvs/messaging2/lib/python3.6/site-packages/pika/connection.py", line 1384, in _process_callbacks
    frame_value)  # Args
  File "/Users/roman/virtualenvs/messaging2/lib/python3.6/site-packages/pika/callback.py", line 60, in wrapper
    return function(*tuple(args), **kwargs)
  File "/Users/roman/virtualenvs/messaging2/lib/python3.6/site-packages/pika/callback.py", line 92, in wrapper
    return function(*args, **kwargs)
  File "/Users/roman/virtualenvs/messaging2/lib/python3.6/site-packages/pika/callback.py", line 236, in process
    callback(*args, **keywords)
  File "/Users/roman/virtualenvs/messaging2/src/aio-pika/aio_pika/adapter.py", line 235, in _on_getempty
    self._on_getempty_callback(method_frame)
  File "/Users/roman/virtualenvs/messaging2/src/aio-pika/aio_pika/queue.py", line 252, in _on_getempty
    f.set_result(None)
asyncio.base_futures.InvalidStateError: invalid state
2018-06-13 01:07:23 INFO Channel.close(200, Normal shutdown)
2018-06-13 01:07:23 INFO Channel.close(200, Normal shutdown)
2018-06-13 01:07:23 INFO Closing connection (200): Normal shutdown
2018-06-13 01:07:23 WARNING Disconnected from RabbitMQ at 127.0.0.1:5672 (200): Normal shutdown
```

This is frequently reproducable in my tests. This PR helps me to fix this issue.