### PR TITLE
fixed inconsistent argument type for connection.connect

### DIFF
--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -387,8 +387,8 @@ def connect(url: str=None, *, host: str='localhost',
 
     ssl_options = ssl_options or {}
 
-    if url:
-        url = URL(str(url))
+    if url is not None:
+        url = URL(url)
         host = url.host or host
         port = url.port or port
         login = url.user or login

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -42,7 +42,7 @@ class AsyncTestCase(asynctest.TestCase):
 class BaseTestCase(AsyncTestCase):
     @asyncio.coroutine
     def create_connection(self, cleanup=True) -> Generator[Any, None, Connection]:
-        client = yield from connect(AMQP_URL, loop=self.loop)
+        client = yield from connect(str(AMQP_URL), loop=self.loop)
 
         if cleanup:
             self.addCleanup(client.close)

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -766,7 +766,7 @@ class TestCase(BaseTestCase):
 
         with self.assertRaises(ProbableAuthenticationError):
             yield from connect(
-                amqp_url,
+                str(amqp_url),
                 loop=self.loop
             )
 

--- a/tests/test_amqp_robust.py
+++ b/tests/test_amqp_robust.py
@@ -10,7 +10,7 @@ from tests.test_amqp import TestCase as AMQPTestCase
 class TestCase(AMQPTestCase):
     @asyncio.coroutine
     def create_connection(self, cleanup=True):
-        client = yield from connect_robust(AMQP_URL, loop=self.loop)
+        client = yield from connect_robust(str(AMQP_URL), loop=self.loop)
 
         if cleanup:
             self.addCleanup(client.close)

--- a/tests/test_amqp_without_publisher_confirms_robust.py
+++ b/tests/test_amqp_without_publisher_confirms_robust.py
@@ -10,7 +10,7 @@ from tests.test_amqp_without_publisher_confirms import TestCase as AMQPTestCase
 class TestCase(AMQPTestCase):
     @asyncio.coroutine
     def create_connection(self, cleanup=True):
-        client = yield from connect_robust(AMQP_URL, loop=self.loop)
+        client = yield from connect_robust(str(AMQP_URL), loop=self.loop)
 
         if cleanup:
             self.addCleanup(client.close)


### PR DESCRIPTION
connection.connect is declared to expect 'url' argument as either `str` or `None`
but in tests it was called with `yarl.URL` instance

Also optional argument should tested to be None instead of implicit bool cast. In this case the problem might be that an empty string, which is a valid url, would be ignored by connection.connect.