### PR TITLE
Fixed Deprecation Warnings in Python 3.7

### DIFF
--- a/aio_pika/pika/utils.py
+++ b/aio_pika/pika/utils.py
@@ -13,4 +13,4 @@ def is_callable(handle):
     :rtype: bool
 
     """
-    return isinstance(handle, collections.Callable)
+    return isinstance(handle, collections.abc.Callable)


### PR DESCRIPTION
When using or importing abstract base classes from Python's `collections` module, these must be explicitely used from `collections.abc` instead of from `collections` directly. This commit solves the resulting DeprecationWarning.