### PR TITLE
Move waiting for connection outside of locked section

### DIFF
--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -244,12 +244,13 @@ class Channel(BaseChannel):
     async def _publish(self, queue_name, routing_key, body,
                        properties: BasicProperties, mandatory, immediate):
 
+        while self._connection.is_closed:
+            log.debug(
+                "Can't publish message because connection is inactive"
+            )
+            await asyncio.sleep(1, loop=self.loop)
+
         async with self._write_lock:
-            while self._connection.is_closed:
-                log.debug(
-                    "Can't publish message because connection is inactive"
-                )
-                await asyncio.sleep(1, loop=self.loop)
 
             f = self._create_future()
             self._delivery_tag += 1

--- a/aio_pika/version.py
+++ b/aio_pika/version.py
@@ -7,7 +7,7 @@ package_license = "Apache Software License"
 
 team_email = 'me@mosquito.su'
 
-version_info = (4, 3, 0)
+version_info = (4, 3, 1)
 
 __author__ = ", ".join("{} <{}>".format(*info) for info in author_info)
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
When we are trying to send message while connection is closed
we wait in loop until it is open again. However, because this
is in self._write_lock no other function can access this section
including creating new pika channel. Therefore new channel never
opens and then we get an exception that old channel has already
closed exception.

This should resolve my problem specified here https://github.com/mosquito/aio-pika/issues/112#issuecomment-432111405