### PR TITLE
RobustConnection fixes

### DIFF
--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -111,6 +111,10 @@ class Channel(BaseChannel):
         await self.close()
 
     def _on_channel_close(self, channel: PikaChannel, code: int, reason):
+        # We have to check if the channel has already been closed, as this
+        # could have been done within `_publish` method
+        if self.is_closed:
+            return
         # In case of normal closing, closing code should be unaltered
         # (0 by default)
         # See: https://github.com/pika/pika/blob/8d970e1/pika/channel.py#L84

--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -1,4 +1,5 @@
 import asyncio
+from contextlib import suppress
 from functools import wraps
 from logging import getLogger
 from typing import Callable
@@ -47,6 +48,7 @@ class RobustConnection(Connection):
         self._on_connection_lost_callbacks = []
         self._on_reconnect_callbacks = []
         self._on_close_callbacks = []
+        self._connecting = None
 
     def add_connection_lost_callback(self, callback: Callable[[], None]):
         """ Add callback which will be called after connection was lost.
@@ -72,6 +74,12 @@ class RobustConnection(Connection):
 
         self._on_close_callbacks.append(lambda c: callback(c))
 
+    def _on_connection_open(self, future: asyncio.Future,
+                            connection: AsyncioConnection):
+        super()._on_connection_open(future, connection)
+        if self._connecting and not self._connecting.done():
+            self._connecting.set_result(connection)
+
     def _on_connection_lost(self, future: asyncio.Future,
                             connection: AsyncioConnection, code, reason):
         for callback in self._on_connection_lost_callbacks:
@@ -91,7 +99,7 @@ class RobustConnection(Connection):
 
         self.loop.call_later(
             self.reconnect_interval,
-            lambda: self.loop.create_task(self.connect())
+            lambda: self.loop.create_task(self.reconnect())
         )
 
     def _channel_cleanup(self, channel: PikaChannel):
@@ -110,12 +118,18 @@ class RobustConnection(Connection):
         self._on_channel_error(channel)
 
     async def connect(self):
-        result = await super().connect()
+        self._connecting = self.loop.create_future()
+        await self.reconnect()
+        result = await self._connecting
+        return result
 
-        while self._connection is None:
-            await asyncio.sleep(self.reconnect_interval, loop=self.loop)
-            result = await super().connect()
+    async def reconnect(self):
+        with suppress(Exception):
+            # Calls `_on_connection_lost` in case of errors
+            if await super().connect():
+                await self.on_reconnect()
 
+    async def on_reconnect(self):
         for number, channel in tuple(self._channels.items()):
             try:
                 await channel.on_reconnect(self, number)
@@ -125,8 +139,6 @@ class RobustConnection(Connection):
 
         for callback in self._on_reconnect_callbacks:
             callback(self)
-
-        return result
 
     @property
     def is_closed(self):

--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -133,7 +133,7 @@ class RobustConnection(Connection):
         for number, channel in tuple(self._channels.items()):
             try:
                 await channel.on_reconnect(self, number)
-            except ChannelClosed:
+            except (RuntimeError, ChannelClosed):
                 self._on_channel_error(channel._channel)
                 return
 

--- a/aio_pika/tools.py
+++ b/aio_pika/tools.py
@@ -1,7 +1,7 @@
 import asyncio
 from functools import partial, wraps
 
-__all__ = 'wait', 'create_task', 'iscoroutinepartial'
+__all__ = 'wait', 'create_task', 'iscoroutinepartial', 'shield'
 
 
 def iscoroutinepartial(fn):
@@ -74,11 +74,3 @@ def shield(func):
         return wraps(func)(awaiter)(asyncio.shield(func(*args, **kwargs)))
 
     return wrap
-
-
-def future_check_wrap(future: asyncio.Future):
-    def on_called(result):
-        if not future.done():
-            future.set_result(result)
-
-    return on_called


### PR DESCRIPTION
Fixes robust reconnecting and the following errors during reconnecting:

1. Exception `RuntimeError("Can't initialize closed channel")`
2. Exception `InvalidStateError`:
```
ERROR:aio_pika.channel:Failed to send data to client (connection unexpectedly closed)
Traceback (most recent call last):
  File "/home/decaz/workspace/aio-pika/aio_pika/channel.py", line 263, in _publish
    self._channel.basic_publish(
AttributeError: 'NoneType' object has no attribute 'basic_publish'
Traceback (most recent call last):
  File "/home/decaz/workspace/aio-pika/aio_pika/channel.py", line 263, in _publish
    self._channel.basic_publish(
AttributeError: 'NoneType' object has no attribute 'basic_publish'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test_101.py", line 26, in <module>
    loop.run_until_complete(main(loop))
  File "/usr/lib/python3.6/asyncio/base_events.py", line 467, in run_until_complete
    return future.result()
  File "test_101.py", line 18, in main
    routing_key = routing_key
  File "/home/decaz/workspace/aio-pika/aio_pika/common.py", line 122, in wrap
    return await func(self, *args, **kwargs)
  File "/home/decaz/workspace/aio-pika/aio_pika/exchange.py", line 203, in publish
    immediate=immediate
  File "/home/decaz/workspace/aio-pika/aio_pika/common.py", line 122, in wrap
    return await func(self, *args, **kwargs)
  File "/home/decaz/workspace/aio-pika/aio_pika/channel.py", line 272, in _publish
    self._on_channel_close(self._channel, -1, exc)
  File "/home/decaz/workspace/aio-pika/aio_pika/channel.py", line 123, in _on_channel_close
    self._closing.set_exception(exc)
asyncio.base_futures.InvalidStateError: invalid state
```

Refs #112 