### PR TITLE
Fix UnboundLocalError exception

### DIFF
--- a/aio_pika/pika/adapters/base_connection.py
+++ b/aio_pika/pika/adapters/base_connection.py
@@ -437,6 +437,7 @@ class BaseConnection(connection.Connection):
                             errno.ECONNABORTED,
                             errno.errorcode[errno.ECONNABORTED]
                         )
+                    break
 
                 bytes_written += bw
                 if bw < len(frame):


### PR DESCRIPTION
Fix of the following exception:
```UnboundLocalError: local variable 'bw' referenced before assignment```

Refs #112 