### PR TITLE
Queue redeclare fails on reconnect if queue is passive

### DIFF
--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -311,10 +311,11 @@ class Channel(BaseChannel):
 
             queue = self.QUEUE_CLASS(
                 self.loop, self._futures.get_child(), self._channel, name,
-                durable, exclusive, auto_delete, arguments
+                durable, exclusive, auto_delete, arguments,
+                passive=passive
             )
 
-            await queue.declare(timeout, passive=passive)
+            await queue.declare(timeout)
             return queue
 
     async def close(self) -> None:

--- a/aio_pika/robust_queue.py
+++ b/aio_pika/robust_queue.py
@@ -18,13 +18,17 @@ DeclarationResult = namedtuple(
 
 
 class RobustQueue(Queue):
+    __slots__ = ('_consumers', '_bindings')
+
     def __init__(self, loop: asyncio.AbstractEventLoop,
                  future_store: FutureStore, channel: Channel,
-                 name, durable, exclusive, auto_delete, arguments):
+                 name, durable, exclusive, auto_delete, arguments,
+                 passive: bool = False):
 
         super().__init__(loop, future_store, channel,
                          name or "amq_%s" % shortuuid.uuid(),
-                         durable, exclusive, auto_delete, arguments)
+                         durable, exclusive, auto_delete, arguments,
+                         passive=passive)
 
         self._consumers = {}
         self._bindings = {}

--- a/aio_pika/version.py
+++ b/aio_pika/version.py
@@ -7,7 +7,7 @@ package_license = "Apache Software License"
 
 team_email = 'me@mosquito.su'
 
-version_info = (4, 7, 1)
+version_info = (4, 8, 0)
 
 __author__ = ", ".join("{} <{}>".format(*info) for info in author_info)
 __version__ = ".".join(map(str, version_info))

--- a/aio_pika/version.py
+++ b/aio_pika/version.py
@@ -7,7 +7,7 @@ package_license = "Apache Software License"
 
 team_email = 'me@mosquito.su'
 
-version_info = (4, 7, 0)
+version_info = (4, 7, 1)
 
 __author__ = ", ".join("{} <{}>".format(*info) for info in author_info)
 __version__ = ".".join(map(str, version_info))

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -125,6 +125,7 @@ Thanks for contributing
 .. _@decaz: https://github.com/decaz
 .. _@kajetanj: https://github.com/kajetanj
 .. _@iselind: https://github.com/iselind
+.. _@driverx: https://github.com/DriverX
 
 
 Versioning

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -144,6 +144,38 @@ class TestCase(BaseTestCase):
             channel=channel2
         )
 
+    async def test_declare_queue_with_passive_flag(self):
+        client = await self.create_connection()
+
+        queue_name = self.get_random_name()
+        channel = await client.channel()
+
+        with pytest.raises(aio_pika.exceptions.ChannelClosed):
+            await self.declare_queue(
+                queue_name,
+                auto_delete=True,
+                passive=True,
+                channel=channel
+            )
+
+        channel1 = await client.channel()
+        channel2 = await client.channel()
+
+        await self.declare_queue(
+            queue_name,
+            auto_delete=True,
+            passive=False,
+            channel=channel1
+        )
+
+        # Check ignoring different queue options
+        await self.declare_queue(
+            queue_name,
+            auto_delete=False,
+            passive=True,
+            channel=channel2
+        )
+
     async def test_simple_publish_and_receive(self):
         queue_name = self.get_random_name("test_connection")
         routing_key = self.get_random_name()

--- a/tests/test_amqp_robust.py
+++ b/tests/test_amqp_robust.py
@@ -1,4 +1,6 @@
+import asyncio
 import pytest
+from contextlib import suppress
 
 from aio_pika import connect_robust
 from tests import AMQP_URL
@@ -20,3 +22,49 @@ class TestCase(AMQPTestCase):
     async def test_set_qos(self):
         channel = await self.create_channel()
         await channel.set_qos(prefetch_count=1)
+
+    async def test_revive_passive_queue_on_reconnect(self):
+        client1 = await self.create_connection()
+        client2 = await self.create_connection()
+
+        reconnect_event = asyncio.Event()
+        reconnect_count = 0
+
+        def reconnect_callback(conn):
+            nonlocal reconnect_count
+            reconnect_count += 1
+            reconnect_event.set()
+            reconnect_event.clear()
+
+        client2.add_reconnect_callback(reconnect_callback)
+
+        queue_name = self.get_random_name()
+        channel1 = await client1.channel()
+        channel2 = await client2.channel()
+        queue_name, channel1, channel2, asyncio
+
+        await self.declare_queue(
+            queue_name,
+            auto_delete=False,
+            passive=False,
+            channel=channel1
+        )
+        await self.declare_queue(
+            queue_name,
+            passive=True,
+            channel=channel2
+        )
+
+        client2._connection.close(320, 'Closed')
+
+        await reconnect_event.wait()
+
+        self.assertEqual(reconnect_count, 1)
+
+        with suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(
+                reconnect_event.wait(),
+                client2.reconnect_interval * 2
+            )
+
+        self.assertEqual(reconnect_count, 1)


### PR DESCRIPTION
On reconnect passive queues tries redeclared in creation mode and fails over and over again.