### PR TITLE
Allow `pool` module to be referenced from `aio_pika`

### DIFF
--- a/aio_pika/__init__.py
+++ b/aio_pika/__init__.py
@@ -1,4 +1,5 @@
 from . import patterns
+from . import pool
 from .connection import Connection, connect
 from .channel import Channel
 from .exchange import Exchange, ExchangeType
@@ -28,6 +29,7 @@ __all__ = (
     'author_info',
     'package_info',
     'patterns',
+    'pool',
     'version_info',
     'package_license',
     'AMQPException',

--- a/aio_pika/version.py
+++ b/aio_pika/version.py
@@ -7,7 +7,7 @@ package_license = "Apache Software License"
 
 team_email = 'me@mosquito.su'
 
-version_info = (4, 8, 2)
+version_info = (4, 9, 2)
 
 __author__ = ", ".join("{} <{}>".format(*info) for info in author_info)
 __version__ = ".".join(map(str, version_info))

--- a/aio_pika/version.py
+++ b/aio_pika/version.py
@@ -7,7 +7,7 @@ package_license = "Apache Software License"
 
 team_email = 'me@mosquito.su'
 
-version_info = (4, 8, 1)
+version_info = (4, 8, 2)
 
 __author__ = ", ".join("{} <{}>".format(*info) for info in author_info)
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
Referencing `pool` from `aio_pika` currently fails with `AttributeError: module 'aio_pika' has no attribute 'pool'`. You can still import `pool` directly (e.g. `from aio_pika import pool`), but it would be nice to reference a bunch of things from a simple `import aio_pika`.

Exposing it in `aio_pika.__init__` does the trick.