### PR TITLE
Fix changing from named queue to random queue

### DIFF
--- a/docs/source/rabbitmq-tutorial/examples/4-routing/receive_logs_direct.py
+++ b/docs/source/rabbitmq-tutorial/examples/4-routing/receive_logs_direct.py
@@ -34,13 +34,13 @@ async def main(loop):
         'logs', ExchangeType.DIRECT
     )
 
-    # Declaring queue
-    queue = await channel.declare_queue('task_queue', durable=True)
+    # Declaring random queue
+    queue = await channel.declare_queue(durable=True)
 
     for severity in severities:
         await queue.bind(direct_logs_exchange, routing_key=severity)
 
-    # Start listening the queue with name 'task_queue'
+    # Start listening the random queue
     await queue.consume(on_message)
 
 


### PR DESCRIPTION
Declaring a random queue, each consumer binds its **unique** queue with desired routing_key to the direct exchange

Before, the consumer declared the queue named 'task_queue'. That made each consumer to listener to the **same** queue. Even if bound to the direct exchange with different routing_key, the consumer was receiving all the message in round robin way.