### PR TITLE
Pool: use None instead of Elipsis for initial state

### DIFF
--- a/aio_pika/pool.py
+++ b/aio_pika/pool.py
@@ -73,4 +73,3 @@ class PoolItemContextManager(AsyncContextManager):
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self.item is not None:
             self.pool.put(self.item)
- 

--- a/aio_pika/pool.py
+++ b/aio_pika/pool.py
@@ -64,12 +64,12 @@ class PoolItemContextManager(AsyncContextManager):
 
     def __init__(self, pool: Pool):
         self.pool = pool
-        self.item = ...
+        self.item = None
 
     async def __aenter__(self) -> T:
         self.item = await self.pool._get()
         return self.item
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        if self.item is not ...:
+        if self.item is not None:
             self.pool.put(self.item)

--- a/aio_pika/pool.py
+++ b/aio_pika/pool.py
@@ -73,3 +73,4 @@ class PoolItemContextManager(AsyncContextManager):
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self.item is not None:
             self.pool.put(self.item)
+ 


### PR DESCRIPTION
Usage of None is standard on Python for uninitialized objects, while Ellipsis is mostly used as a helper for slicing multidimensional lists/arrays.
Using None provides clarity and simplicity.

Signed-off-by: Antonio Gutierrez <chibby0ne@gmail.com>