### PR TITLE
Make pika connections async, move _adapter_connect to a thread pool

### DIFF
--- a/aio_pika/adapter.py
+++ b/aio_pika/adapter.py
@@ -136,8 +136,8 @@ class AsyncioConnection(base_connection.BaseConnection):
                          on_close_callback, self.ioloop,
                          stop_ioloop_on_close=stop_ioloop_on_close)
 
-    def _adapter_connect(self):
-        error = super()._adapter_connect()
+    async def _adapter_connect(self):
+        error = await self.loop.run_in_executor(None, self._sync_adapter_connect)
 
         if not error:
             self.ioloop.add_handler(

--- a/aio_pika/adapter.py
+++ b/aio_pika/adapter.py
@@ -137,7 +137,9 @@ class AsyncioConnection(base_connection.BaseConnection):
                          stop_ioloop_on_close=stop_ioloop_on_close)
 
     async def _adapter_connect(self):
-        error = await self.loop.run_in_executor(None, self._sync_adapter_connect)
+        error = await self.loop.run_in_executor(
+            None, self._sync_adapter_connect
+        )
 
         if not error:
             self.ioloop.add_handler(

--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -230,6 +230,8 @@ class Connection:
                 on_open_error_callback=partial(self._on_connection_refused, f),
             )
 
+            await connection.connect()
+
             connection.channel_cleanup_callback = self._channel_cleanup
             connection.channel_cancel_callback = self._on_channel_cancel
 

--- a/aio_pika/pika/adapters/base_connection.py
+++ b/aio_pika/pika/adapters/base_connection.py
@@ -112,7 +112,7 @@ class BaseConnection(connection.Connection):
         """
         self.ioloop.remove_timeout(timeout_id)
 
-    def _adapter_connect(self):
+    def _sync_adapter_connect(self):
         """Connect to the RabbitMQ broker, returning True if connected.
 
         :returns: error string or exception instance on error; None on success

--- a/aio_pika/pika/connection.py
+++ b/aio_pika/pika/connection.py
@@ -610,7 +610,6 @@ class Connection(object):
 
         # Initialize the connection state and connect
         self._init_connection_state()
-        self.connect()
 
     def add_backpressure_callback(self, callback_method):
         """Call method "callback" when pika believes backpressure is being
@@ -736,13 +735,13 @@ class Connection(object):
             # called in _on_channel_cleanup once all channels have been closed
             self._on_close_ready()
 
-    def connect(self):
+    async def connect(self):
         """Invoke if trying to reconnect to a RabbitMQ server. Constructing the
         Connection object should connect on its own.
 
         """
         self._set_connection_state(self.CONNECTION_INIT)
-        error = self._adapter_connect()
+        error = await self._adapter_connect()
         if not error:
             return self._on_connected()
         self.remaining_connection_attempts -= 1
@@ -848,7 +847,7 @@ class Connection(object):
     # Internal methods for managing the communication process
     #
 
-    def _adapter_connect(self):
+    async def _adapter_connect(self):
         """Subclasses should override to set up the outbound socket connection.
 
         :raises: NotImplementedError


### PR DESCRIPTION
Laziest approach, this code could really leverage asyncio's high level connection stuff.

----

For #124 

This is mostly just a RFC, I don't expect this to get merged, but it works as expected and i'm fairly sure it's thread safe.

The most important change here, regardless of the approach taken, is to remove the connect() call from `pika.connection.Connection.__init__`, which can never be async, and to move it to an explicit call after creating the instance, so that it can be awaited.

I went for minimal but not quite API-clean changes - I don't know what API guarantees should be kept here, or what's the desired extent of changes to the vendored pika, if any.

At first I avoided changing the vendored pika but later I realized its BaseConnection is nothing like the upstream one, so I simplified things. In an [earlier implementation of this change][1] I didn't touch pika at all but had to override `connect()` with a no-op and copy a whole method.

[1]: https://github.com/dequis/aio-pika/commit/f531a1aea51a6c9a76acb86db9cb30dcaa2e9972