### PR TITLE
Add `success_close_codes` channel parameter

### DIFF
--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -243,7 +243,8 @@ class Connection:
     @_ensure_connection
     def channel(self, channel_number: int=None,
                 publisher_confirms: bool=True,
-                on_return_raises=False) -> Channel:
+                on_return_raises: bool=False,
+                success_close_codes: tuple=(0,)) -> Channel:
         """ Coroutine which returns new instance of :class:`Channel`.
 
         Example:
@@ -295,13 +296,16 @@ class Connection:
         :param on_return_raises:
             raise an :class:`aio_pika.exceptions.UnroutableError`
             when mandatory message will be returned
+        :param success_close_codes: don't set exception and don't log error if
+            the channel was closed with specified codes
         """
         log.debug("Creating AMQP channel for connection: %r", self)
 
         channel = self.CHANNEL_CLASS(self, self.loop, self.future_store,
                                      channel_number=channel_number,
                                      publisher_confirms=publisher_confirms,
-                                     on_return_raises=on_return_raises)
+                                     on_return_raises=on_return_raises,
+                                     success_close_codes=success_close_codes)
 
         log.debug("Channel created: %r", channel)
         return channel

--- a/aio_pika/robust_channel.py
+++ b/aio_pika/robust_channel.py
@@ -28,16 +28,23 @@ class RobustChannel(Channel):
 
     def __init__(self, connection, loop: asyncio.AbstractEventLoop,
                  future_store: FutureStore, channel_number: int=None,
-                 publisher_confirms: bool=True, on_return_raises=False):
+                 publisher_confirms: bool=True, on_return_raises=False,
+                 success_close_codes: tuple=(0,)):
         """
 
         :param connection: :class:`aio_pika.adapter.AsyncioConnection` instance
         :param loop:
             Event loop (:func:`asyncio.get_event_loop()` when :class:`None`)
         :param future_store: :class:`aio_pika.common.FutureStore` instance
+        :param channel_number: specify the channel number explicit
         :param publisher_confirms:
             False if you don't need delivery confirmations
             (in pursuit of performance)
+        :param on_return_raises:
+            raise an :class:`aio_pika.exceptions.UnroutableError`
+            when mandatory message will be returned
+        :param success_close_codes: don't set exception and don't log error if
+            the channel was closed with specified codes
         """
         super().__init__(
             loop=loop,
@@ -46,6 +53,7 @@ class RobustChannel(Channel):
             channel_number=channel_number,
             publisher_confirms=publisher_confirms,
             on_return_raises=on_return_raises,
+            success_close_codes=success_close_codes,
         )
 
         self._closed = False


### PR DESCRIPTION
I'm intentionally create exclusive queue with the same name multiple times and gracefully handle channel closing. But `aio-pika` interprets it as exception with error code `405 (RESOURCE_LOCKED)`. In my case it should be ignored.