### PR TITLE
Fix HeaderProxy bug

### DIFF
--- a/aio_pika/message.py
+++ b/aio_pika/message.py
@@ -163,7 +163,7 @@ class HeaderProxy(Mapping):
 
     def __iter__(self):
         for key in self._headers:
-            yield key, self[key]
+            yield key
 
 
 @singledispatch

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -1407,7 +1407,10 @@ class TestCase(BaseTestCase):
 
 class MessageTestCase(unittest.TestCase):
     def test_message_copy(self):
-        msg1 = Message(bytes(shortuuid.uuid(), 'utf-8'))
+        msg1 = Message(
+            bytes(shortuuid.uuid(), 'utf-8'),
+            headers={'h1': 'v1', 'h2': 'v2'},
+        )
         msg2 = copy(msg1)
 
         msg1.lock()


### PR DESCRIPTION
`HeaderProxy` has incorrect iterator behaviour, which breaks `Message.__copy__`.