### PR TITLE
Fix encode timestamp error on copy

### DIFF
--- a/aio_pika/message.py
+++ b/aio_pika/message.py
@@ -163,7 +163,7 @@ class HeaderProxy(Mapping):
 
     def __iter__(self):
         for key in self._headers:
-            yield key, self[key]
+            yield key
 
 
 @singledispatch

--- a/aio_pika/message.py
+++ b/aio_pika/message.py
@@ -86,6 +86,11 @@ def encode_timestamp(value) -> Optional[time.struct_time]:
     raise ValueError('Invalid timestamp type: %r' % type(value), value)
 
 
+@encode_timestamp.register(time.struct_time)
+def _(value):
+    return value
+
+
 @encode_timestamp.register(datetime)
 def _(value):
     return value.timetuple()

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -1407,7 +1407,10 @@ class TestCase(BaseTestCase):
 
 class MessageTestCase(unittest.TestCase):
     def test_message_copy(self):
-        msg1 = Message(bytes(shortuuid.uuid(), 'utf-8'))
+        msg1 = Message(
+            bytes(shortuuid.uuid(), 'utf-8'),
+            headers={'h1': 'v1', 'h2': 'v2'},
+        )
         msg2 = copy(msg1)
 
         msg1.lock()

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -1409,6 +1409,9 @@ class MessageTestCase(unittest.TestCase):
     def test_message_copy(self):
         msg1 = Message(
             bytes(shortuuid.uuid(), 'utf-8'),
+            content_type='application/json',
+            content_encoding='text',
+            timestamp=datetime(2000, 1, 1),
             headers={'h1': 'v1', 'h2': 'v2'},
         )
         msg2 = copy(msg1)


### PR DESCRIPTION
`encode_timestamp` fails on `time.time_struct` value