### PR TITLE
Update setup.py to include py.typed marker file.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     packages=find_packages(exclude=['tests']),
+    package_data={'aio_pika': ['py.typed']},
     install_requires=[
         'aiormq~=2.1',
         'yarl',


### PR DESCRIPTION
To make the aio_pika package PEP-561 compatible, it needs to indicate
the presence of the marker file in the setup.py file. This ensures
installing the package as a typed package.

Currently if you run mypy on any package that uses aio_pika it errors out like:
```shell
error: Cannot find module named 'aio_pika'
```