### PR TITLE
Removed None assignemnts to non-optional attributes.

### DIFF
--- a/aio_pika/message.py
+++ b/aio_pika/message.py
@@ -450,12 +450,8 @@ class IncomingMessage(Message):
         )
 
         self.cluster_id = message.header.properties.cluster_id
-
-        self.cluster_id = None
         self.consumer_tag = None
         self.delivery_tag = None
-        self.exchange = None
-        self.routing_key = None
         self.redelivered = None
         self.message_count = None
 


### PR DESCRIPTION
Unnecessary `None` assignments cause mypy to see these fields as `Optional` even though the have acutal value assigned in `__init__`