### PR TITLE
Add typing_extensions for 3.5 and 3.6 support

### DIFF
--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -1,7 +1,12 @@
 import asyncio
 from enum import unique, Enum
 from logging import getLogger
-from typing import Callable, Any, Union, Awaitable
+from typing import Callable, Any, Union
+
+try:  # pragma: no cover
+    from typing import Awaitable  # noqa
+except ImportError:
+    from typing_extensions import Awaitable  # noqa
 
 import aiormq
 import aiormq.types

--- a/aio_pika/message.py
+++ b/aio_pika/message.py
@@ -10,7 +10,10 @@ from pprint import pformat
 from typing import Union, Optional, Any, Callable, Dict, Iterable
 from warnings import warn
 
-from typing import AsyncContextManager
+try:  # pragma: no cover
+    from typing import AsyncContextManager  # noqa
+except ImportError:
+    from typing_extensions import AsyncContextManager  # noqa
 
 import aiormq
 from aiormq.types import DeliveredMessage

--- a/aio_pika/pool.py
+++ b/aio_pika/pool.py
@@ -1,6 +1,11 @@
 import asyncio
 import logging
-from typing import Any, AsyncContextManager, Callable, Coroutine, TypeVar
+from typing import Any, Callable, TypeVar
+
+try:  # pragma: no cover
+    from typing import AsyncContextManager, Coroutine  # noqa
+except ImportError:
+    from typing_extensions import AsyncContextManager, Coroutine  # noqa
 
 
 T = TypeVar("T")

--- a/aio_pika/robust_channel.py
+++ b/aio_pika/robust_channel.py
@@ -1,4 +1,9 @@
-from typing import Callable, Any, Union, Awaitable
+from typing import Callable, Any, Union
+
+try:  # pragma: no cover
+    from typing import Awaitable  # noqa
+except ImportError:
+    from typing_extensions import Awaitable  # noqa
 
 from logging import getLogger
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     install_requires=[
         'aiormq~=2.3',
         'yarl',
+        'typing_extensions>=3.6.5; python_version<"3.7"',
     ],
     python_requires=">3.5.*, <4",
     extras_require={


### PR DESCRIPTION
This change adds the `typing_extensions` module to allow support for Python 3.5 and 3.6 including PyPy.