### PR TITLE
fix return type of Queue.bind

### DIFF
--- a/aio_pika/queue.py
+++ b/aio_pika/queue.py
@@ -92,7 +92,7 @@ class Queue:
     async def bind(
         self, exchange: ExchangeType_, routing_key: str=None, *,
         arguments=None, timeout: int=None
-    ) -> aiormq.spec.Queue.DeclareOk:
+    ) -> aiormq.spec.Queue.BindOk:
 
         """ A binding is a relationship between an exchange and a queue.
         This can be simply read as: the queue is interested in messages


### PR DESCRIPTION
During debugging in stumbled on an odd return type of `Queue.bind` that seems to be a typo.

This appears to be inconsequential as the type is not checked by default.

Note that there is an actual runtime check in `Channel.rpc` for `valid_responses` and the return type is in fact `BindOk`.

I have not actually tested the patch as there isn't a test case where it fails.