### PR TITLE
[Message] Fix: set header value on HeaderProxy

### DIFF
--- a/aio_pika/message.py
+++ b/aio_pika/message.py
@@ -164,7 +164,7 @@ class HeaderProxy(Mapping):
         return self._cache[k]
 
     def __setitem__(self, key, value):
-        self._headers[key] = format_headers(value)
+        self._headers[key] = header_converter(value)
         self._cache.pop(key, None)
 
     def __len__(self) -> int:

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -1564,3 +1564,23 @@ class MessageTestCase(unittest.TestCase):
             self.assertEqual(
                 msg.headers['value'], value, "%r != %r" % (src, value)
             )
+
+    def test_headers_set(self):
+        msg = Message(b'', headers={'header': 'value'})
+
+        data = (
+            ['header-1', 42, 42, 42],
+            ['header-2', 'foo', b'foo', 'foo'],
+            ['header-3', b'\00', b'\00', '\00'],
+        )
+
+        for name, src, raw, value in data:
+            msg.headers[name] = value
+            self.assertEqual(
+                msg.headers_raw[name], raw, "%r != %r" % (src, raw)
+            )
+            self.assertEqual(
+                msg.headers[name], value, "%r != %r" % (src, value)
+            )
+
+        self.assertEqual(msg.headers['header'], 'value')


### PR DESCRIPTION
`HeadersProxy.__setitem__` has call to `format_headers` in order to format value, but `format_headers`, it seems, supposed to be called with entire headers mapping, not an individual value (and it will raise an AttributeError if called just with a string).

I've replaced the call of `format_headers(value)` in `HeadersProxy.__setitem__` code by `header_converter(value)` call to fix this bug.

Also, this PR features a test case for individual header set for the `Message` instance.