### PR TITLE
Fix robust connection

### DIFF
--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -94,7 +94,7 @@ class Connection:
         """
         self.close_callbacks.add(callback)
 
-    def _on_connection_close(self, connection, closing, *a, **kw):
+    def _on_connection_close(self, connection, closing, *args, **kwargs):
         exc = closing.exception()
 
         for cb in self.close_callbacks:

--- a/aio_pika/exceptions.py
+++ b/aio_pika/exceptions.py
@@ -1,5 +1,6 @@
 import asyncio
 
+import pamqp
 from aiormq.exceptions import (
     AMQPChannelError,
     AMQPConnectionError,
@@ -18,6 +19,11 @@ from aiormq.exceptions import (
     ChannelPreconditionFailed,
     ChannelNotFoundEntity
 )
+
+PAMQP_EXCEPTIONS = (pamqp.exceptions.PAMQPException,) + tuple(
+    pamqp.specification.ERRORS.values()
+)
+CONNECTION_EXCEPTIONS = (ConnectionError, AMQPError) + PAMQP_EXCEPTIONS
 
 
 class MessageProcessError(AMQPError):


### PR DESCRIPTION
There is unexpected `return` statement within connection loop so `connect` method will return after the first iteration.