### PR TITLE
Extended ExchangeType

### DIFF
--- a/aio_pika/exchange.py
+++ b/aio_pika/exchange.py
@@ -19,6 +19,7 @@ class ExchangeType(Enum):
     HEADERS = 'headers'
     X_DELAYED_MESSAGE = 'x-delayed-message'
     X_CONSISTENT_HASH = 'x-consistent-hash'
+    X_MODULUS_HASH = 'x-modulus-hash'
 
 
 class Exchange:


### PR DESCRIPTION
Hello, 
I think the type exchange restriction is strong. Sometimes you need exchange type which haven't been added yet. For example, has been created new plugin and __aio_pika__ has not been updated yet