### PR TITLE
Fix documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,13 +222,13 @@ Clone the project:
     git clone https://github.com/mosquito/aio-pika.git
     cd aio-pika
 
-Create a new virtualenv for `aio_pika`_:
+Create a new virtualenv for `aio-pika`_:
 
 .. code-block:: shell
 
     virtualenv -p python3.5 env
 
-Install all requirements for `aio_pika`_:
+Install all requirements for `aio-pika`_:
 
 .. code-block:: shell
 
@@ -269,4 +269,4 @@ The changes should follow simple rules:
 
 .. _"thank's to" section: https://github.com/mosquito/aio-pika/blob/master/docs/source/index.rst#thanks-for-contributing
 .. _Semantic Versioning: http://semver.org/
-.. _aio_pika: https://github.com/mosquito/aio-pika/
+.. _aio-pika: https://github.com/mosquito/aio-pika/

--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -257,24 +257,18 @@ async def connect(
         will be used keyword arguments.
     :param host: hostname of the broker
     :param port: broker port 5672 by default
-    :param login:
-        username string. `'guest'` by default. Provide empty string
-        for pika.credentials.ExternalCredentials usage.
+    :param login: username string. `'guest'` by default.
     :param password: password string. `'guest'` by default.
     :param virtualhost: virtualhost parameter. `'/'` by default
-    :param ssl:
-        use SSL for connection. Should be used with addition kwargs.
-        See `pika documentation`_ for more info.
+    :param ssl: use SSL for connection. Should be used with addition kwargs.
     :param ssl_options: A dict of values for the SSL connection.
     :param loop:
         Event loop (:func:`asyncio.get_event_loop()` when :class:`None`)
     :param connection_class: Factory of a new connection
-    :param kwargs:
-        addition parameters which will be passed to the pika connection.
+    :param kwargs: addition parameters which will be passed to the connection.
     :return: :class:`aio_pika.connection.Connection`
 
     .. _RFC3986: https://goo.gl/MzgYAs
-    .. _pika documentation: https://goo.gl/TdVuZ9
     .. _official Python documentation: https://goo.gl/pty9xA
 
 

--- a/aio_pika/exchange.py
+++ b/aio_pika/exchange.py
@@ -117,7 +117,7 @@ class Exchange:
 
         :param exchange: :class:`aio_pika.exchange.Exchange` instance
         :param routing_key: routing key
-        :param arguments: additional arguments (will be passed to `pika`)
+        :param arguments: additional arguments
         :param timeout: execution timeout
         :return: :class:`None`
         """
@@ -146,7 +146,7 @@ class Exchange:
 
         :param exchange: :class:`aio_pika.exchange.Exchange` instance
         :param routing_key: routing key
-        :param arguments: additional arguments (will be passed to `pika`)
+        :param arguments: additional arguments
         :param timeout: execution timeout
         :return: :class:`None`
         """
@@ -171,7 +171,7 @@ class Exchange:
         immediate: bool = False, timeout: TimeoutType = None
     ) -> Optional[aiormq.types.ConfirmationFrameType]:
 
-        """ Publish the message to the queue. `aio_pika` use
+        """ Publish the message to the queue. `aio-pika` uses
         `publisher confirms`_ extension for message delivery.
 
         .. _publisher confirms: https://www.rabbitmq.com/confirms.html

--- a/aio_pika/message.py
+++ b/aio_pika/message.py
@@ -352,7 +352,7 @@ class Message:
 
     @property
     def properties(self) -> aiormq.spec.Basic.Properties:
-        """ Build :class:`pika.BasicProperties` object """
+        """ Build :class:`aiormq.spec.Basic.Properties` object """
         return aiormq.spec.Basic.Properties(
             content_type=self.content_type,
             content_encoding=self.content_encoding,
@@ -410,7 +410,7 @@ class Message:
 
 
 class IncomingMessage(Message):
-    """ Incoming message it's seems like Message but has additional methods for
+    """ Incoming message is seems like Message but has additional methods for
     message acknowledgement.
 
     Depending on the acknowledgement mode used, RabbitMQ can consider a
@@ -528,9 +528,9 @@ class IncomingMessage(Message):
         """ Send basic.ack is used for positive acknowledgements
 
         .. note::
-            This method looks like a blocking-method, but actually it's
-            just send bytes to the socket and not required any responses
-            from the broker.
+            This method looks like a blocking-method, but actually it just
+            sends bytes to the socket and doesn't require any responses from
+            the broker.
 
         :param multiple: If set to True, the message's delivery tag is
                          treated as "up to and including", so that multiple
@@ -561,8 +561,8 @@ class IncomingMessage(Message):
         Otherwise message will be dropped.
 
         .. note::
-            This method looks like a blocking-method, but actually it's just
-            send bytes to the socket and not required any responses from
+            This method looks like a blocking-method, but actually it just
+            sends bytes to the socket and doesn't require any responses from
             the broker.
 
         :param requeue: bool

--- a/aio_pika/queue.py
+++ b/aio_pika/queue.py
@@ -105,7 +105,7 @@ class Queue:
 
         :param exchange: :class:`aio_pika.exchange.Exchange` instance
         :param routing_key: routing key
-        :param arguments: additional arguments (will be passed to `pika`)
+        :param arguments: additional arguments
         :param timeout: execution timeout
         :raises asyncio.TimeoutError:
             when the binding timeout period has elapsed.
@@ -138,7 +138,7 @@ class Queue:
 
         :param exchange: :class:`aio_pika.exchange.Exchange` instance
         :param routing_key: routing key
-        :param arguments: additional arguments (will be passed to `pika`)
+        :param arguments: additional arguments
         :param timeout: execution timeout
         :raises asyncio.TimeoutError:
             when the unbinding timeout period has elapsed.
@@ -181,7 +181,7 @@ class Queue:
             be accessed by the current connection, and are deleted
             when that connection closes. Passive declaration of an
             exclusive queue by other connections are not allowed.
-        :param arguments: extended arguments for pika
+        :param arguments: additional arguments
         :param consumer_tag: optional consumer tag
 
         :raises asyncio.TimeoutError:

--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -202,24 +202,18 @@ async def connect_robust(url: str = None, *, host: str = 'localhost',
         will be used keyword arguments.
     :param host: hostname of the broker
     :param port: broker port 5672 by default
-    :param login:
-        username string. `'guest'` by default. Provide empty string
-        for pika.credentials.ExternalCredentials usage.
+    :param login: username string. `'guest'` by default.
     :param password: password string. `'guest'` by default.
     :param virtualhost: virtualhost parameter. `'/'` by default
-    :param ssl:
-        use SSL for connection. Should be used with addition kwargs.
-        See `pika documentation`_ for more info.
+    :param ssl: use SSL for connection. Should be used with addition kwargs.
     :param ssl_options: A dict of values for the SSL connection.
     :param loop:
         Event loop (:func:`asyncio.get_event_loop()` when :class:`None`)
     :param connection_class: Factory of a new connection
-    :param kwargs:
-        addition parameters which will be passed to the pika connection.
+    :param kwargs: addition parameters which will be passed to the connection.
     :return: :class:`aio_pika.connection.Connection`
 
     .. _RFC3986: https://goo.gl/MzgYAs
-    .. _pika documentation: https://goo.gl/TdVuZ9
     .. _official Python documentation: https://goo.gl/pty9xA
 
     """

--- a/aio_pika/tools.py
+++ b/aio_pika/tools.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 
 def iscoroutinepartial(fn):
     """
-    Function returns True if function it's a partial instance of coroutine.
+    Function returns True if function is a partial instance of coroutine.
     See additional information here_.
 
     :param fn: Function

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -112,7 +112,7 @@ html_theme = 'alabaster'
 # html_theme_options = {}
 html_theme_options = {
     'codecov_button': True,
-    'description': 'Wrapper for the PIKA for asyncio and humans',
+    'description': 'Wrapper for the aiormq for asyncio and humans',
     'github_banner': True,
     'github_button': True,
     'github_repo': 'aio-pika',

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,9 +3,9 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-.. _aio_pika: https://github.com/mosquito/aio-pika
+.. _aio-pika: https://github.com/mosquito/aio-pika
 .. _asyncio: https://docs.python.org/3/library/asyncio.html
-.. _PIKA: https://github.com/pika/pika
+.. _aiormq: http://github.com/mosquito/aiormq/
 
 
 Welcome to aio-pika's documentation!
@@ -33,7 +33,7 @@ Welcome to aio-pika's documentation!
     :target: https://pypi.python.org/pypi/aio-pika/
 
 
-`aio_pika`_ it's a wrapper for the `PIKA`_ for `asyncio`_ and humans.
+`aio-pika`_ is a wrapper for the `aiormq`_ for `asyncio`_ and humans.
 
 
 Features
@@ -80,13 +80,13 @@ Clone the project:
     cd aio-pika
 
 
-Create a new virtualenv for `aio_pika`_:
+Create a new virtualenv for `aio-pika`_:
 
 .. code-block:: shell
 
     virtualenv -p python3.5 env
 
-Install all requirements for `aio_pika`_:
+Install all requirements for `aio-pika`_:
 
 .. code-block:: shell
 

--- a/docs/source/patterns.rst
+++ b/docs/source/patterns.rst
@@ -1,4 +1,4 @@
-.. _aio_pika: https://github.com/mosquito/aio-pika
+.. _aio-pika: https://github.com/mosquito/aio-pika
 
 
 Patterns and helpers
@@ -6,7 +6,7 @@ Patterns and helpers
 
 .. note:: Available since `aio-pika>=1.7.0`
 
-`aio_pika`_ includes some useful patterns for creating distributed systems.
+`aio-pika`_ includes some useful patterns for creating distributed systems.
 
 
 .. _patterns-worker:

--- a/docs/source/rabbitmq-tutorial/1-introduction.rst
+++ b/docs/source/rabbitmq-tutorial/1-introduction.rst
@@ -194,7 +194,7 @@ command as many times as we like, and only one will be created.
 
 .. note::
     This article contains adopted official examples only.
-    But `aio_pika` allows to use Python 3.5+ `async for` notation.
+    But `aio-pika` allows to use Python 3.5+ `async for` notation.
 
     For example:
 


### PR DESCRIPTION
* Mentions of `pika` are removed or changed to `aiormq`
* Renamed `aio_pika` -> `aio-pika`
* Some grammar corrections