### PR TITLE
A one thousandth of a second is a millisecond, not a microsecond

### DIFF
--- a/aio_pika/message.py
+++ b/aio_pika/message.py
@@ -32,11 +32,11 @@ class DeliveryMode(IntEnum):
 
 DateType = Union[int, datetime, float, timedelta, None]
 
-MICROSECONDS = 1000
+MILLISECONDS = 1000
 
 
-def to_microseconds(seconds):
-    return int(seconds * MICROSECONDS)
+def to_milliseconds(seconds):
+    return int(seconds * MILLISECONDS)
 
 
 @singledispatch
@@ -47,13 +47,13 @@ def encode_expiration(value) -> Optional[str]:
 @encode_expiration.register(datetime)
 def _(value):
     now = datetime.now()
-    return str(to_microseconds((value - now).total_seconds()))
+    return str(to_milliseconds((value - now).total_seconds()))
 
 
 @encode_expiration.register(int)
 @encode_expiration.register(float)
 def _(value):
-    return str(to_microseconds(value))
+    return str(to_milliseconds(value))
 
 
 @encode_expiration.register(timedelta)


### PR DESCRIPTION
Fix misnamed variable & function.

My usage of the library looked fine, so was taking a look to verify that the variables were correctly converted for rabbitmq to process and noticed the MICROSECONDS variable and thought that was the problem, it wasn't but figured I'd fix this for you anyway.