### PR TITLE
Add reopen method for channel

### DIFF
--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -186,6 +186,10 @@ class Channel:
     def _on_return(self, message: aiormq.types.DeliveredMessage):
         self._return_callbacks(IncomingMessage(message, no_ack=True))
 
+    async def reopen(self):
+        self._channel = None
+        await self.initialize()
+
     async def declare_exchange(
         self, name: str, type: Union[ExchangeType, str] = ExchangeType.DIRECT,
         durable: bool = None, auto_delete: bool = False,

--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -35,9 +35,7 @@ class RobustConnection(Connection):
     )
 
     def __init__(self, url, loop=None, **kwargs):
-        super().__init__(
-            loop=loop or asyncio.get_event_loop(), url=url, **kwargs
-        )
+        super().__init__(url=url, loop=loop, **kwargs)
 
         self.connect_kwargs = {}
         self.reconnect_interval = self.kwargs['reconnect_interval']
@@ -124,8 +122,8 @@ class RobustConnection(Connection):
                         **self.connect_kwargs
                     )
 
-                    for number, channel in self._channels.items():
-                        await channel.on_reconnect(self, number)
+                    for channel in self._channels.values():
+                        await channel.reopen()
 
                     self.fail_fast = False
                     self.connected.set()

--- a/aio_pika/robust_exchange.py
+++ b/aio_pika/robust_exchange.py
@@ -33,7 +33,7 @@ class RobustExchange(Exchange):
 
         self._bindings = dict()
 
-    async def on_reconnect(self, channel: Channel):
+    async def restore(self, channel: Channel):
         self._channel = channel._channel
 
         await self.declare()

--- a/aio_pika/robust_queue.py
+++ b/aio_pika/robust_queue.py
@@ -44,7 +44,7 @@ class RobustQueue(Queue):
         self._consumers = {}
         self._bindings = {}
 
-    async def on_reconnect(self, channel: Channel):
+    async def restore(self, channel: Channel):
         self._channel = channel._channel
 
         await self.declare()

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -36,9 +36,6 @@ class TestCase(BaseTestCase):
         client = await self.create_connection()
         event = asyncio.Event()
 
-        self.get_random_name("test_connection")
-        self.get_random_name()
-
         self.__closed = False
 
         def on_close(ch):
@@ -59,6 +56,15 @@ class TestCase(BaseTestCase):
             await channel.initialize()
 
         await self.create_channel(connection=client)
+
+    async def test_channel_reopen(self):
+        channel = await self.create_channel()
+
+        await channel.close()
+        self.assertTrue(channel.is_closed)
+
+        await channel.reopen()
+        self.assertFalse(channel.is_closed)
 
     async def test_delete_queue_and_exchange(self):
         queue_name = self.get_random_name("test_connection")


### PR DESCRIPTION
It happens that the channel closes and you need to open it again. In case of robust connection currently this is possible using an inconvenient call:
```python
await channel.on_reconnect(
    connection=channel._connection,
    channel_number=channel._channel_number,
)
```
I suggest to make it as follows:
```python
await channel.reopen()
```
Thereby `on_reconnect` methods should be renamed to `restore` which mean more broad sense than just reconnection.