### PR TITLE
Fix robust connection cleanup

### DIFF
--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -92,6 +92,8 @@ class RobustConnection(Connection):
         self._reconnect_callbacks.add(callback)
 
     async def __cleanup_connection(self, exc):
+        if self.connection is None:
+            return
         await asyncio.gather(
             self.connection.close(exc),
             return_exceptions=True,


### PR DESCRIPTION
The following exception is observable: `AttributeError: 'NoneType' object has no attribute 'close'`.

@mosquito I think it's critical and should be released as soon as possible.