### PR TITLE
Pass loop when connecting to aiormq

### DIFF
--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -321,7 +321,7 @@ async def connect(
     connection = connection_class(url, loop=loop)
 
     await connection.connect(
-        timeout=timeout, client_properties=client_properties
+        timeout=timeout, client_properties=client_properties, loop=loop
     )
     return connection
 


### PR DESCRIPTION
Before the change loop that was passed to aiopika connection was not passed further to aiormq connection and it resulted in having two different loops:
![image](https://user-images.githubusercontent.com/5520634/73854433-d8bc3880-4832-11ea-9a20-8376f9196619.png)
After the change connection is properly passed as an argument further down and we have same instance everywhere:
![image](https://user-images.githubusercontent.com/5520634/73854503-f38ead00-4832-11ea-8449-12a605098204.png)
