### PR TITLE
Fix call close on closed channels

### DIFF
--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -205,8 +205,9 @@ class Connection:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        for channel in tuple(self._channels.values()):
-            await channel.close()
+        for channel in tuple(self._channels.values()):  # _channel can change size
+            if not channel.is_closed:
+                await channel.close()
 
         await self.close()
 

--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -205,7 +205,7 @@ class Connection:
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
-        for channel in tuple(self._channels.values()):  # _channel can change size
+        for channel in tuple(self._channels.values()):  # can change size
             if not channel.is_closed:
                 await channel.close()
 


### PR DESCRIPTION
If write something like

```
rabbitmq_connection: aio_pika.Connection = await aio_pika.connect_robust(
    f"amqp://{rabbitmq_option('username')}:{rabbitmq_option('password')}@{rabbitmq_option('host')}/"
)

async with rabbitmq_connection:
    async with rabbitmq_connection.channel() as channel:
        pass
```

You got warning `Channel already closed`

To solve this problem, I added a channel closedness check.