### PR TITLE
Add docs and github links to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,4 +58,8 @@ setup(
             'tox>=2.4',
         ],
     },
+    project_urls={
+        'Documentation': 'https://aio-pika.readthedocs.org/',
+        'Source': 'https://github.com/mosquito/aio-pika',
+    },
 )


### PR DESCRIPTION
There was no link from the PyPI page to this repository. This will make links appear on the left:

![Screenshot_20200303_141323](https://user-images.githubusercontent.com/426784/75810754-2a37e480-5d59-11ea-8c2c-fff2739e6fe4.png)