### PR TITLE
Add generics to Pool and PoolItemContextManager

### DIFF
--- a/aio_pika/pool.py
+++ b/aio_pika/pool.py
@@ -2,7 +2,8 @@ import abc
 import asyncio
 import logging
 from typing import (
-    Any, AsyncContextManager, Awaitable, Callable, Coroutine, Generic, TypeVar, Union,
+    Any, AsyncContextManager, Awaitable, Callable, Coroutine, Generic, TypeVar,
+    Union,
 )
 
 from aiormq.tools import awaitable

--- a/aio_pika/pool.py
+++ b/aio_pika/pool.py
@@ -19,7 +19,6 @@ class PoolInstance(abc.ABC):
 
 
 T = TypeVar("T")
-ItemType = Coroutine[Any, None, T]
 ConstructorType = Union[
     Awaitable[PoolInstance],
     Callable[..., PoolInstance],


### PR DESCRIPTION
This helps mypy determine the return type when using a pool like:
`async with self.connection_pool.acquire() as connection:`
or
`async with self.channel_pool.acquire() as channel:`

Without this, mypy was telling me to set type for the `connection` and `channel` variables.