### PR TITLE
Conditionally reconnect RobustConnection

### DIFF
--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -75,6 +75,9 @@ class RobustConnection(Connection):
 
         super()._on_connection_close(connection, closing)
 
+        if self._closed:
+            return
+
         log.info(
             "Connection to %s closed. Reconnecting after %r seconds.",
             self,


### PR DESCRIPTION
RobustConnection was reconnecting whenever the connection was lost,
even if the connection had been closed on pupose by invoking
`connection.close()`. The reconnect code now tests if a reconnect
attempt should be made at all by consulting `self._closed`.