### PR TITLE
Fix body arg annotation in Message.__init__ method.

### DIFF
--- a/aio_pika/message.py
+++ b/aio_pika/message.py
@@ -242,7 +242,7 @@ class Message:
 
     def __init__(
         self,
-        body: bytes,
+        body: Union[bytes, str],
         *,
         headers: dict = None,
         content_type: str = None,


### PR DESCRIPTION
## What do these changes do?


There is an incorrect annotation in `aio_pika.message.Message`:
```python
class Message:
    def __init__(self, body: bytes, ...):
        self.body = body if isinstance(body, bytes) else bytes(body)
```
**body** argument can be a string.

## Are there changes in behavior for the user?

No.