### PR TITLE
Improve documentation examples and snippets

### DIFF
--- a/docs/source/rabbitmq-tutorial/1-introduction.rst
+++ b/docs/source/rabbitmq-tutorial/1-introduction.rst
@@ -124,7 +124,7 @@ thing we need to do is to establish a connection with RabbitMQ server.
 
 .. literalinclude:: examples/1-introduction/send.py
    :language: python
-   :lines: 6-10
+   :lines: 5-9
 
 We're connected now, to a broker on the local machine - hence the localhost.
 If we wanted to connect to a broker on a different machine we'd simply specify
@@ -150,14 +150,14 @@ message should go. The queue name needs to be specified in the *routing_key* par
 
 .. literalinclude:: examples/1-introduction/send.py
    :language: python
-   :lines: 12-16
+   :lines: 11-20
 
 Before exiting the program we need to make sure the network buffers were flushed and our
 message was actually delivered to RabbitMQ. We can do it by gently closing the connection.
 
 .. literalinclude:: examples/1-introduction/send.py
    :language: python
-   :lines: 19
+   :lines: 22
 
 .. note::
 

--- a/docs/source/rabbitmq-tutorial/1-introduction.rst
+++ b/docs/source/rabbitmq-tutorial/1-introduction.rst
@@ -124,7 +124,7 @@ thing we need to do is to establish a connection with RabbitMQ server.
 
 .. literalinclude:: examples/1-introduction/send.py
    :language: python
-   :lines: 5-9
+   :lines: 6-10
 
 We're connected now, to a broker on the local machine - hence the localhost.
 If we wanted to connect to a broker on a different machine we'd simply specify
@@ -136,7 +136,7 @@ Let's create a queue to which the message will be delivered, let's name it *hell
 
 .. literalinclude:: examples/1-introduction/receive.py
    :language: python
-   :lines: 26-27
+   :lines: 24-25
 
 At that point we're ready to send a message. Our first message will just contain a
 string Hello World! and we want to send it to our hello queue.
@@ -150,14 +150,14 @@ message should go. The queue name needs to be specified in the *routing_key* par
 
 .. literalinclude:: examples/1-introduction/send.py
    :language: python
-   :lines: 11-20
+   :lines: 12-16
 
 Before exiting the program we need to make sure the network buffers were flushed and our
 message was actually delivered to RabbitMQ. We can do it by gently closing the connection.
 
 .. literalinclude:: examples/1-introduction/send.py
    :language: python
-   :lines: 22
+   :lines: 19
 
 .. note::
 
@@ -190,7 +190,7 @@ command as many times as we like, and only one will be created.
 
 .. literalinclude:: examples/1-introduction/receive.py
    :language: python
-   :lines: 18-30
+   :lines: 18-28
 
 .. note::
     This article contains adopted official examples only.
@@ -200,7 +200,7 @@ command as many times as we like, and only one will be created.
 
     .. literalinclude:: ../examples/simple_consumer.py
        :language: python
-       :lines: 12-26
+       :lines: 12-25
 
 You may ask why we declare the queue again ‒ we have already declared it in
 our previous code. We could avoid that if we were sure that the queue already exists.

--- a/docs/source/rabbitmq-tutorial/2-work-queues.rst
+++ b/docs/source/rabbitmq-tutorial/2-work-queues.rst
@@ -67,7 +67,7 @@ queue, so let's name it *new_task.py*:
 
 .. literalinclude:: examples/2-work-queues/new_task.py
    :language: python
-   :lines: 15-27
+   :lines: 10-22
 
 Our old receive.py script also requires some changes: it needs to fake a second of work
 for every dot in the message body. It will pop messages from the queue and perform the task,
@@ -75,7 +75,7 @@ so let's call it *worker.py*:
 
 .. literalinclude:: examples/2-work-queues/worker.py
    :language: python
-   :lines: 10-11
+   :lines: 8-11
 
 
 Round-robin dispatching
@@ -272,7 +272,7 @@ acknowledged the previous one. Instead, it will dispatch it to the next worker t
 
 .. literalinclude:: examples/2-work-queues/worker.py
    :language: python
-   :lines: 20-22
+   :lines: 20
 
 
 .. note::

--- a/docs/source/rabbitmq-tutorial/2-work-queues.rst
+++ b/docs/source/rabbitmq-tutorial/2-work-queues.rst
@@ -67,7 +67,7 @@ queue, so let's name it *new_task.py*:
 
 .. literalinclude:: examples/2-work-queues/new_task.py
    :language: python
-   :lines: 10-22
+   :lines: 13-26
 
 Our old receive.py script also requires some changes: it needs to fake a second of work
 for every dot in the message body. It will pop messages from the queue and perform the task,
@@ -75,7 +75,7 @@ so let's call it *worker.py*:
 
 .. literalinclude:: examples/2-work-queues/worker.py
    :language: python
-   :lines: 8-11
+   :lines: 9-10
 
 
 Round-robin dispatching
@@ -167,7 +167,7 @@ or using special context processor:
 
 .. literalinclude:: examples/2-work-queues/worker.py
    :language: python
-   :lines: 8-12
+   :lines: 7-10
 
 
 If context processor will catch an exception, the message will be returned to the queue.
@@ -207,7 +207,7 @@ we need to declare it as *durable*:
 
 .. literalinclude:: examples/2-work-queues/worker.py
    :language: python
-   :lines: 25,27-28
+   :lines: 22,24-25
 
 
 Although this command is correct by itself, it won't work in our setup.
@@ -218,7 +218,7 @@ But there is a quick workaround - let's declare a queue with different name, for
 
 .. literalinclude:: examples/2-work-queues/worker.py
    :language: python
-   :lines: 25-28
+   :lines: 22-25
 
 This queue_declare change needs to be applied to both the producer and consumer code.
 
@@ -272,7 +272,7 @@ acknowledged the previous one. Instead, it will dispatch it to the next worker t
 
 .. literalinclude:: examples/2-work-queues/worker.py
    :language: python
-   :lines: 20
+   :lines: 17-19
 
 
 .. note::

--- a/docs/source/rabbitmq-tutorial/3-publish-subscribe.rst
+++ b/docs/source/rabbitmq-tutorial/3-publish-subscribe.rst
@@ -76,7 +76,7 @@ We'll focus on the last one — the fanout. Let's create an exchange of that typ
 
 .. literalinclude:: examples/3-publish-subscribe/emit_log.py
    :language: python
-   :lines: 15-17
+   :lines: 13
 
 The fanout exchange is very simple. As you can probably guess from the name, it just broadcasts
 all the messages it receives to all the queues it knows. And that's exactly what we need for our logger.
@@ -123,7 +123,7 @@ Now, we can publish to our named exchange instead:
 
 .. literalinclude:: examples/3-publish-subscribe/emit_log.py
    :language: python
-   :lines: 19-27
+   :lines: 20
 
 
 Temporary queues
@@ -150,7 +150,7 @@ Secondly, once we disconnect the consumer the queue should be deleted. There's a
 
 .. literalinclude:: examples/3-publish-subscribe/receive_logs.py
    :language: python
-   :lines: 28
+   :lines: 28-29
 
 Bindings
 ++++++++
@@ -163,7 +163,7 @@ send messages to our queue. That relationship between exchange and a queue is ca
 
 .. literalinclude:: examples/3-publish-subscribe/receive_logs.py
    :language: python
-   :lines: 22-31
+   :lines: 22-29
 
 From now on the logs exchange will append messages to our queue.
 

--- a/docs/source/rabbitmq-tutorial/3-publish-subscribe.rst
+++ b/docs/source/rabbitmq-tutorial/3-publish-subscribe.rst
@@ -76,7 +76,7 @@ We'll focus on the last one — the fanout. Let's create an exchange of that typ
 
 .. literalinclude:: examples/3-publish-subscribe/emit_log.py
    :language: python
-   :lines: 13
+   :lines: 15-17
 
 The fanout exchange is very simple. As you can probably guess from the name, it just broadcasts
 all the messages it receives to all the queues it knows. And that's exactly what we need for our logger.
@@ -123,7 +123,7 @@ Now, we can publish to our named exchange instead:
 
 .. literalinclude:: examples/3-publish-subscribe/emit_log.py
    :language: python
-   :lines: 20
+   :lines: 19-28
 
 
 Temporary queues
@@ -150,7 +150,7 @@ Secondly, once we disconnect the consumer the queue should be deleted. There's a
 
 .. literalinclude:: examples/3-publish-subscribe/receive_logs.py
    :language: python
-   :lines: 28-29
+   :lines: 27
 
 Bindings
 ++++++++
@@ -163,7 +163,7 @@ send messages to our queue. That relationship between exchange and a queue is ca
 
 .. literalinclude:: examples/3-publish-subscribe/receive_logs.py
    :language: python
-   :lines: 22-29
+   :lines: 22-30
 
 From now on the logs exchange will append messages to our queue.
 

--- a/docs/source/rabbitmq-tutorial/6-rpc.rst
+++ b/docs/source/rabbitmq-tutorial/6-rpc.rst
@@ -197,14 +197,14 @@ The code for :download:`rpc_client.py <examples/6-rpc/rpc_client.py>`:
 The client code is slightly more involved:
 
 * (15) We establish a connection, channel and declare an exclusive 'callback' queue for replies.
-* (18) We subscribe to the 'callback' queue, so that we can receive RPC responses.
-* (22) The 'on_response' callback executed on every response is doing a very simple job,
+* (22) We subscribe to the 'callback' queue, so that we can receive RPC responses.
+* (26) The 'on_response' callback executed on every response is doing a very simple job,
   for every response message it checks if the correlation_id is the one we're looking for.
   If so, it saves the response in self.response and breaks the consuming loop.
-* (26) Next, we define our main call method - it does the actual RPC request.
-* (27) In this method, first we generate a unique correlation_id number and save it - the 'on_response' callback
+* (30) Next, we define our main call method - it does the actual RPC request.
+* (31) In this method, first we generate a unique correlation_id number and save it - the 'on_response' callback
   function will use this value to catch the appropriate response.
-* (32) Next, we publish the request message, with two properties: reply_to and correlation_id.
+* (36) Next, we publish the request message, with two properties: reply_to and correlation_id.
   And finally we return the response back to the user.
 
 Our RPC service is now ready. We can start the server::

--- a/docs/source/rabbitmq-tutorial/examples/1-introduction/receive.py
+++ b/docs/source/rabbitmq-tutorial/examples/1-introduction/receive.py
@@ -16,7 +16,9 @@ async def on_message(message: IncomingMessage):
 
 async def main(loop):
     # Perform connection
-    connection = await connect("amqp://guest:guest@localhost/", loop=loop)
+    connection = await connect(
+        "amqp://guest:guest@localhost/", loop=loop
+    )
 
     # Creating a channel
     channel = await connection.channel()

--- a/docs/source/rabbitmq-tutorial/examples/1-introduction/send.py
+++ b/docs/source/rabbitmq-tutorial/examples/1-introduction/send.py
@@ -4,14 +4,17 @@ from aio_pika import connect, Message
 
 async def main(loop):
     # Perform connection
-    connection = await connect("amqp://guest:guest@localhost/", loop=loop)
+    connection = await connect(
+        "amqp://guest:guest@localhost/", loop=loop
+    )
 
     # Creating a channel
     channel = await connection.channel()
 
     # Sending the message
     await channel.default_exchange.publish(
-        Message(b"Hello World!"), routing_key="hello",
+        Message(b"Hello World!"),
+        routing_key="hello",
     )
 
     print(" [x] Sent 'Hello World!'")

--- a/docs/source/rabbitmq-tutorial/examples/2-work-queues/new_task.py
+++ b/docs/source/rabbitmq-tutorial/examples/2-work-queues/new_task.py
@@ -10,12 +10,18 @@ async def main(loop):
     # Creating a channel
     channel = await connection.channel()
 
-    message_body = bytes(" ".join(sys.argv[1:]), 'utf-8') or b"Hello World!"
+    message_body = b" ".join(
+        arg.encode() for arg in sys.argv[1:]) or b"Hello World!"
 
-    message = Message(message_body, delivery_mode=DeliveryMode.PERSISTENT)
+    message = Message(
+        message_body,
+        delivery_mode=DeliveryMode.PERSISTENT
+    )
 
     # Sending the message
-    await channel.default_exchange.publish(message, routing_key="task_queue")
+    await channel.default_exchange.publish(
+        message, routing_key="task_queue"
+    )
 
     print(" [x] Sent %r" % message)
 

--- a/docs/source/rabbitmq-tutorial/examples/2-work-queues/new_task.py
+++ b/docs/source/rabbitmq-tutorial/examples/2-work-queues/new_task.py
@@ -10,7 +10,7 @@ async def main(loop):
     # Creating a channel
     channel = await connection.channel()
 
-    message_body = b" ".join(sys.argv[1:]) or b"Hello World!"
+    message_body = bytes(" ".join(sys.argv[1:]), 'utf-8') or b"Hello World!"
 
     message = Message(message_body, delivery_mode=DeliveryMode.PERSISTENT)
 

--- a/docs/source/rabbitmq-tutorial/examples/2-work-queues/worker.py
+++ b/docs/source/rabbitmq-tutorial/examples/2-work-queues/worker.py
@@ -1,7 +1,6 @@
 import asyncio
 from aio_pika import connect, IncomingMessage
 
-
 loop = asyncio.get_event_loop()
 
 
@@ -17,11 +16,13 @@ async def main():
 
     # Creating a channel
     channel = await connection.channel()
-    
     await channel.set_qos(prefetch_count=1)
 
     # Declaring queue
-    queue = await channel.declare_queue("task_queue", durable=True)
+    queue = await channel.declare_queue(
+        "task_queue",
+        durable=True
+    )
 
     # Start listening the queue with name 'task_queue'
     await queue.consume(on_message)

--- a/docs/source/rabbitmq-tutorial/examples/2-work-queues/worker.py
+++ b/docs/source/rabbitmq-tutorial/examples/2-work-queues/worker.py
@@ -6,7 +6,7 @@ loop = asyncio.get_event_loop()
 
 
 def on_message(message: IncomingMessage):
-    with message.process():
+    async with message.process():
         print(" [x] Received message %r" % message)
         print("     Message body is: %r" % message.body)
 
@@ -17,6 +17,7 @@ async def main():
 
     # Creating a channel
     channel = await connection.channel()
+    
     await channel.set_qos(prefetch_count=1)
 
     # Declaring queue

--- a/docs/source/rabbitmq-tutorial/examples/3-publish-subscribe/emit_log.py
+++ b/docs/source/rabbitmq-tutorial/examples/3-publish-subscribe/emit_log.py
@@ -12,7 +12,7 @@ async def main(loop):
 
     logs_exchange = await channel.declare_exchange("logs", ExchangeType.FANOUT)
 
-    message_body = b" ".join(sys.argv[1:]) or b"Hello World!"
+    message_body = bytes(" ".join(sys.argv[1:]), 'utf-8') or b"Hello World!"
 
     message = Message(message_body, delivery_mode=DeliveryMode.PERSISTENT)
 

--- a/docs/source/rabbitmq-tutorial/examples/3-publish-subscribe/emit_log.py
+++ b/docs/source/rabbitmq-tutorial/examples/3-publish-subscribe/emit_log.py
@@ -5,16 +5,24 @@ from aio_pika import connect, Message, DeliveryMode, ExchangeType
 
 async def main(loop):
     # Perform connection
-    connection = await connect("amqp://guest:guest@localhost/", loop=loop)
+    connection = await connect(
+        "amqp://guest:guest@localhost/", loop=loop
+    )
 
     # Creating a channel
     channel = await connection.channel()
 
-    logs_exchange = await channel.declare_exchange("logs", ExchangeType.FANOUT)
+    logs_exchange = await channel.declare_exchange(
+        "logs", ExchangeType.FANOUT
+    )
 
-    message_body = bytes(" ".join(sys.argv[1:]), 'utf-8') or b"Hello World!"
+    message_body = b" ".join(
+        arg.encode() for arg in sys.argv[1:]) or b"Hello World!"
 
-    message = Message(message_body, delivery_mode=DeliveryMode.PERSISTENT)
+    message = Message(
+        message_body,
+        delivery_mode=DeliveryMode.PERSISTENT
+    )
 
     # Sending the message
     await logs_exchange.publish(message, routing_key="info")

--- a/docs/source/rabbitmq-tutorial/examples/3-publish-subscribe/receive_logs.py
+++ b/docs/source/rabbitmq-tutorial/examples/3-publish-subscribe/receive_logs.py
@@ -11,13 +11,17 @@ def on_message(message: IncomingMessage):
 
 async def main():
     # Perform connection
-    connection = await connect("amqp://guest:guest@localhost/", loop=loop)
+    connection = await connect(
+        "amqp://guest:guest@localhost/", loop=loop
+    )
 
     # Creating a channel
     channel = await connection.channel()
     await channel.set_qos(prefetch_count=1)
 
-    logs_exchange = await channel.declare_exchange("logs", ExchangeType.FANOUT)
+    logs_exchange = await channel.declare_exchange(
+        "logs", ExchangeType.FANOUT
+    )
 
     # Declaring queue
     queue = await channel.declare_queue(exclusive=True)

--- a/docs/source/rabbitmq-tutorial/examples/3-publish-subscribe/receive_logs.py
+++ b/docs/source/rabbitmq-tutorial/examples/3-publish-subscribe/receive_logs.py
@@ -5,7 +5,7 @@ loop = asyncio.get_event_loop()
 
 
 def on_message(message: IncomingMessage):
-    with message.process():
+    async with message.process():
         print("[x] %r" % message.body)
 
 

--- a/docs/source/rabbitmq-tutorial/examples/4-routing/emit_log_direct.py
+++ b/docs/source/rabbitmq-tutorial/examples/4-routing/emit_log_direct.py
@@ -13,7 +13,7 @@ async def main(loop):
     logs_exchange = await channel.declare_exchange("logs", ExchangeType.DIRECT)
 
     message_body = (
-        b" ".join(arg.encode() for arg in sys.argv[2:]) or b"Hello World!"
+        bytes(" ".join(arg.encode() for arg in sys.argv[2:]), 'utf-8') or b"Hello World!"
     )
 
     message = Message(message_body, delivery_mode=DeliveryMode.PERSISTENT)

--- a/docs/source/rabbitmq-tutorial/examples/4-routing/emit_log_direct.py
+++ b/docs/source/rabbitmq-tutorial/examples/4-routing/emit_log_direct.py
@@ -5,18 +5,24 @@ from aio_pika import connect, Message, DeliveryMode, ExchangeType
 
 async def main(loop):
     # Perform connection
-    connection = await connect("amqp://guest:guest@localhost/", loop=loop)
+    connection = await connect(
+        "amqp://guest:guest@localhost/", loop=loop
+    )
 
     # Creating a channel
     channel = await connection.channel()
 
-    logs_exchange = await channel.declare_exchange("logs", ExchangeType.DIRECT)
-
-    message_body = (
-        bytes(" ".join(arg.encode() for arg in sys.argv[2:]), 'utf-8') or b"Hello World!"
+    logs_exchange = await channel.declare_exchange(
+        "logs", ExchangeType.DIRECT
     )
 
-    message = Message(message_body, delivery_mode=DeliveryMode.PERSISTENT)
+    message_body = b" ".join(
+        arg.encode() for arg in sys.argv[2:]) or b"Hello World!"
+
+    message = Message(
+        message_body,
+        delivery_mode=DeliveryMode.PERSISTENT
+    )
 
     # Sending the message
     routing_key = sys.argv[1] if len(sys.argv) > 2 else "info"

--- a/docs/source/rabbitmq-tutorial/examples/4-routing/receive_logs_direct.py
+++ b/docs/source/rabbitmq-tutorial/examples/4-routing/receive_logs_direct.py
@@ -10,7 +10,9 @@ def on_message(message: IncomingMessage):
 
 async def main(loop):
     # Perform connection
-    connection = await connect("amqp://guest:guest@localhost/", loop=loop)
+    connection = await connect(
+        "amqp://guest:guest@localhost/", loop=loop
+    )
 
     # Creating a channel
     channel = await connection.channel()
@@ -19,7 +21,9 @@ async def main(loop):
     severities = sys.argv[1:]
 
     if not severities:
-        sys.stderr.write("Usage: %s [info] [warning] [error]\n" % sys.argv[0])
+        sys.stderr.write(
+            "Usage: %s [info] [warning] [error]\n" % sys.argv[0]
+        )
         sys.exit(1)
 
     # Declare an exchange

--- a/docs/source/rabbitmq-tutorial/examples/5-topics/emit_log_topic.py
+++ b/docs/source/rabbitmq-tutorial/examples/5-topics/emit_log_topic.py
@@ -17,7 +17,7 @@ async def main(loop):
     routing_key = sys.argv[1] if len(sys.argv) > 2 else "anonymous.info"
 
     message_body = (
-        b" ".join(arg.encode() for arg in sys.argv[2:]) or b"Hello World!"
+        bytes(" ".join(arg.encode() for arg in sys.argv[2:]), 'utf-8') or b"Hello World!"
     )
 
     message = Message(message_body, delivery_mode=DeliveryMode.PERSISTENT)

--- a/docs/source/rabbitmq-tutorial/examples/5-topics/emit_log_topic.py
+++ b/docs/source/rabbitmq-tutorial/examples/5-topics/emit_log_topic.py
@@ -5,7 +5,9 @@ from aio_pika import connect, Message, DeliveryMode, ExchangeType
 
 async def main(loop):
     # Perform connection
-    connection = await connect("amqp://guest:guest@localhost/", loop=loop)
+    connection = await connect(
+        "amqp://guest:guest@localhost/", loop=loop
+    )
 
     # Creating a channel
     channel = await connection.channel()
@@ -16,11 +18,13 @@ async def main(loop):
 
     routing_key = sys.argv[1] if len(sys.argv) > 2 else "anonymous.info"
 
-    message_body = (
-        bytes(" ".join(arg.encode() for arg in sys.argv[2:]), 'utf-8') or b"Hello World!"
-    )
+    message_body = b" ".join(
+        arg.encode() for arg in sys.argv[2:]) or b"Hello World!"
 
-    message = Message(message_body, delivery_mode=DeliveryMode.PERSISTENT)
+    message = Message(
+        message_body,
+        delivery_mode=DeliveryMode.PERSISTENT
+    )
 
     # Sending the message
     await topic_logs_exchange.publish(message, routing_key=routing_key)

--- a/docs/source/rabbitmq-tutorial/examples/5-topics/receive_logs_topic.py
+++ b/docs/source/rabbitmq-tutorial/examples/5-topics/receive_logs_topic.py
@@ -10,7 +10,9 @@ def on_message(message: IncomingMessage):
 
 async def main(loop):
     # Perform connection
-    connection = await connect("amqp://guest:guest@localhost/", loop=loop)
+    connection = await connect(
+        "amqp://guest:guest@localhost/", loop=loop
+    )
 
     # Creating a channel
     channel = await connection.channel()
@@ -22,7 +24,9 @@ async def main(loop):
     )
 
     # Declaring queue
-    queue = await channel.declare_queue("task_queue", durable=True)
+    queue = await channel.declare_queue(
+        "task_queue", durable=True
+    )
 
     binding_keys = sys.argv[1:]
 

--- a/docs/source/rabbitmq-tutorial/examples/6-rpc/rpc_server.py
+++ b/docs/source/rabbitmq-tutorial/examples/6-rpc/rpc_server.py
@@ -20,7 +20,10 @@ async def on_message(exchange: Exchange, message: IncomingMessage):
         response = str(fib(n)).encode()
 
         await exchange.publish(
-            Message(body=response, correlation_id=message.correlation_id),
+            Message(
+                body=response,
+                correlation_id=message.correlation_id
+            ),
             routing_key=message.reply_to,
         )
         print("Request complete")
@@ -28,7 +31,9 @@ async def on_message(exchange: Exchange, message: IncomingMessage):
 
 async def main(loop):
     # Perform connection
-    connection = await connect("amqp://guest:guest@localhost/", loop=loop)
+    connection = await connect(
+        "amqp://guest:guest@localhost/", loop=loop
+    )
 
     # Creating a channel
     channel = await connection.channel()
@@ -37,7 +42,9 @@ async def main(loop):
     queue = await channel.declare_queue("rpc_queue")
 
     # Start listening the queue with name 'hello'
-    await queue.consume(partial(on_message, channel.default_exchange))
+    await queue.consume(partial(
+        on_message, channel.default_exchange)
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix rabbitmq tutorial documentation problems:

 - There was a disparity between what the current tutorial was
   explaining and what code snippet was showing
 - Fixed formatting for current documentation tutorial snippets (in
   rabbitmq tutorial)
 - Fix disparity between line numbers in part 6 of tutorial and source
   code
 - Using `b' '.join(arg.encode() for arg in sys.argv[1:]` for getting user input in part 2 and 3 instead of `b' '.join(sys.argv[1:])` (later won't work in Python 3)
