### PR TITLE
Restore RobustChannel.default_exchange on reconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ ENV/
 
 # User-specific stuff:
 .idea/
+.vscode/
 
 ## File-based project format:
 *.iws

--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -169,17 +169,18 @@ class Channel(PoolInstance):
 
         self._delivery_tag = 0
 
-        self.default_exchange = self.EXCHANGE_CLASS(
-            connection=self._connection,
-            channel=self.channel,
-            arguments=None,
-            auto_delete=None,
-            durable=None,
-            internal=None,
-            name="",
-            passive=None,
-            type=ExchangeType.DIRECT,
-        )
+        if self.default_exchange is None:
+            self.default_exchange = self.EXCHANGE_CLASS(
+                connection=self._connection,
+                channel=self.channel,
+                arguments=None,
+                auto_delete=None,
+                durable=None,
+                internal=None,
+                name="",
+                passive=None,
+                type=ExchangeType.DIRECT,
+            )
 
         self.channel.on_return_callbacks.add(self._on_return)
 

--- a/aio_pika/robust_channel.py
+++ b/aio_pika/robust_channel.py
@@ -26,7 +26,7 @@ class RobustChannel(Channel):
         connection,
         channel_number: int = None,
         publisher_confirms: bool = True,
-        on_return_raises=False,
+        on_return_raises: bool = False,
     ):
         """
 
@@ -52,16 +52,18 @@ class RobustChannel(Channel):
         self._prefetch_size = 0
         self._global_ = False
 
-    async def reopen(self):
+    async def reopen(self) -> None:
         await super().reopen()
         await self.restore()
 
-    async def restore(self):
+    async def restore(self) -> None:
         await self.set_qos(
             prefetch_count=self._prefetch_count,
             prefetch_size=self._prefetch_size,
             global_=self._global_,
         )
+
+        await self.default_exchange.restore(self)
 
         for exchange in self._exchanges.values():
             await exchange.restore(self)

--- a/aio_pika/robust_exchange.py
+++ b/aio_pika/robust_exchange.py
@@ -44,6 +44,9 @@ class RobustExchange(Exchange):
     async def restore(self, channel: Channel):
         self._channel = channel._channel
 
+        if self.name == "":
+            return
+
         await self.declare()
 
         for exchange, kwargs in self._bindings.items():

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -116,6 +116,7 @@ Thanks for contributing
 * `@decaz`_
 * `@kajetanj`_
 * `@iselind`_
+* `@driverx`_
 
 .. _@mosquito: https://github.com/mosquito
 .. _@hellysmile: https://github.com/hellysmile

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,9 +35,12 @@ async def add_cleanup(loop):
 
 @pytest.fixture
 def amqp_direct_url(request) -> URL:
-    return URL(
+    amqp_url = URL(
         os.getenv("AMQP_URL", "amqp://guest:guest@localhost"),
     ).update_query(name=request.node.nodeid)
+    if amqp_url.port is None:
+        amqp_url = amqp_url.with_port(5672)
+    return amqp_url
 
 
 @pytest.fixture


### PR DESCRIPTION
If connection is closed and Exchange instance from RobustChannel.default_exchange is assigned to some variable, then exchange is not restored.

```python
ch = await robust_conn.channel()
exchange = ch.default_exchange
# connection lost here
# publish method now raises ChannelInvalidStateError (closed)
await exchange.publish(b'message', 'some_queue')
```