### PR TITLE
Fix breaking change in callback definition

### DIFF
--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -136,18 +136,24 @@ class Channel(PoolInstance):
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.close()
 
-    def add_close_callback(self, callback: CloseCallbackType) -> None:
-        self._done_callbacks.add(callback)
+    def add_close_callback(
+        self, callback: CloseCallbackType, weak: bool = False
+    ) -> None:
+        self._done_callbacks.add(callback, weak=weak)
 
-    def remove_close_callback(self, callback: CloseCallbackType) -> None:
-        self._done_callbacks.remove(callback)
+    def remove_close_callback(
+        self, callback: CloseCallbackType, weak: bool = False
+    ) -> None:
+        self._done_callbacks.remove(callback, weak=weak)
 
     def add_on_return_callback(
-        self, callback: ReturnCallbackType, weak: bool = True,
+        self, callback: ReturnCallbackType, weak: bool = False,
     ) -> None:
         self._return_callbacks.add(callback, weak=weak)
 
-    def remove_on_return_callback(self, callback: ReturnCallbackType) -> None:
+    def remove_on_return_callback(
+        self, callback: ReturnCallbackType, weak: bool = False
+    ) -> None:
         self._return_callbacks.remove(callback)
 
     async def _create_channel(self) -> aiormq.Channel:

--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -70,7 +70,9 @@ class Connection(PoolInstance):
     def __repr__(self):
         return '<{0}: "{1}">'.format(self.__class__.__name__, str(self))
 
-    def add_close_callback(self, callback: CloseCallbackType):
+    def add_close_callback(
+        self, callback: CloseCallbackType, weak: bool = False
+    ):
         """ Add callback which will be called after connection will be closed.
 
         :class:`BaseException` or None will be passed as a first argument.
@@ -92,7 +94,7 @@ class Connection(PoolInstance):
 
         :return: None
         """
-        self.close_callbacks.add(callback)
+        self.close_callbacks.add(callback, weak=weak)
 
     def _on_connection_close(self, connection, closing, *args, **kwargs):
         exc = closing.exception()

--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -88,13 +88,15 @@ class RobustConnection(Connection):
             lambda: self.loop.create_task(self.reconnect()),
         )
 
-    def add_reconnect_callback(self, callback: Callable[[], None]):
+    def add_reconnect_callback(
+        self, callback: Callable[[], None], weak: bool = False
+    ):
         """ Add callback which will be called after reconnect.
 
         :return: None
         """
 
-        self._reconnect_callbacks.add(callback)
+        self._reconnect_callbacks.add(callback, weak=weak)
 
     async def __cleanup_connection(self, exc):
         if self.connection is None:

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -991,6 +991,10 @@ class TestCaseAmqp(TestCaseAmqpBase):
             shared_list.append((a, kw))
 
         connection.add_close_callback(share)
+
+        del share
+        assert len(connection.close_callbacks) == 1
+
         await connection.close()
 
         assert len(shared_list) == 1

--- a/tests/test_amqp_robust.py
+++ b/tests/test_amqp_robust.py
@@ -40,6 +40,17 @@ class TestCaseNoRobust(TestCaseAmqp):
 
         return fabric
 
+    async def test_add_reconnect_callback(self, create_connection):
+        connection = await create_connection()
+
+        def cb(*a, **kw):
+            pass
+
+        connection.add_reconnect_callback(cb)
+
+        del cb
+        assert len(connection.reconnect_callbacks) == 1
+
 
 class TestCaseAmqpNoConfirmsRobust(TestCaseAmqpNoConfirms):
     pass


### PR DESCRIPTION
[This commit](https://github.com/mosquito/aio-pika/pull/316/commits/5d3d5451ef33d1e31828bb10cef45e037c44b6f8) introduced the possibility to only store weak references to callbacks in the `CallbackCollection` class. This commit subtly broke the interface by storing all callbacks only weak by default. This PR changes the default back to non-weak and exposes the `weak` parameter of the underlying methods.

Note: I wasn't able to run all tests, because `tests/test_amqp_robust_proxy.py::test_channel_fixture` hangs for me. 😕 

Fixes #331 and #332.