### PR TITLE
Prevent 'Set size changed during iteration'

### DIFF
--- a/aio_pika/robust_channel.py
+++ b/aio_pika/robust_channel.py
@@ -67,7 +67,7 @@ class RobustChannel(Channel):
         await self.default_exchange.restore(self)
 
         for exchanges in self._exchanges.values():
-            for exchange in exchanges:
+            for exchange in exchanges.copy():
                 await exchange.restore(self)
 
         for queues in self._queues.values():


### PR DESCRIPTION
Fixes #388 (possibly?)

Honestly, I'm not sure how to test this, but it feels like the way to
(safely) iterate through a set in an async context, is to iterate
through a copy of the set (or use a lock to that modification of the
set is blocked until iteration is complete).