### PR TITLE
Make Python version compatible with PEP 345

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     package_data={"aio_pika": ["py.typed"]},
     install_requires=["aiormq>=3.2.3,<4", "yarl"],
-    python_requires=">3.5.*, <4",
+    python_requires=">=3.5, <4",
     extras_require={
         "develop": [
             "aiomisc~=10.1.6",


### PR DESCRIPTION
This just changes the `python_requires` in `setup.py` to use the version definition supported by PEP 345.

See [here](https://github.com/python-poetry/poetry/issues/4095#issuecomment-851065187) for how this has become an issue.