### PR TITLE
Fix connection passed to Connection._on_connection_close

### DIFF
--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -104,7 +104,7 @@ class Connection(PoolInstance):
     async def _make_connection(self, **kwargs) -> aiormq.Connection:
         connection = await aiormq.connect(self.url, **kwargs)
         connection.closing.add_done_callback(
-            partial(self._on_connection_close, self.connection),
+            partial(self._on_connection_close, connection),
         )
         return connection
 


### PR DESCRIPTION
Seems like the `connection` argument is used solely for logging, still it's weird to see `Closing AMQP connection None` all the time.