### PR TITLE
Default 2nd arg of RobustChannel._on_channel_close to None

### DIFF
--- a/aio_pika/robust_channel.py
+++ b/aio_pika/robust_channel.py
@@ -75,7 +75,7 @@ class RobustChannel(Channel):
                 await queue.restore(self)
 
     @staticmethod
-    def _on_channel_close(sender, exc: Exception):
+    def _on_channel_close(sender, exc: Exception = None):
         if exc:
             log.exception(
                 "Robust channel %r has been closed.", sender, exc_info=exc,


### PR DESCRIPTION
Without doing this the _on_channel_close method raises an error when
called without the 2nd arg specified.

tools.py:168  Callback error
Traceback (most recent call last):
  File "/opt/conda/lib/python3.7/site-packages/aio_pika/tools.py", line 166, in __call__
    cb(self.__sender(), *args, **kwargs)
TypeError: _on_channel_close() missing 1 required positional argument: 'exc'