### PR TITLE
reduce verbosity of reconnect warnings

### DIFF
--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -141,11 +141,11 @@ class RobustConnection(Connection):
                     await self.__cleanup_connection(e)
 
                     log.warning(
-                        'Connection attempt to "%s" failed. '
+                        'Connection attempt to "%s" failed: %s. '
                         "Reconnecting after %r seconds.",
                         self,
+                        e,
                         self.reconnect_interval,
-                        exc_info=True,
                     )
                 except asyncio.CancelledError as e:
                     await self.__cleanup_connection(e)


### PR DESCRIPTION
Replace the full traceback with a simple inline string of the exception of the failed reconnect attempt.
The full traceback requires many lines and appear frequently in logs (default every 5 s) at high visibility (warning).
At the same time, the traceback offers very little useful extra information in addition to the exception string.