### PR TITLE
fix problem with dangling channels on connection restore

### DIFF
--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -93,6 +93,7 @@ class Channel(PoolInstance):
 
         # noinspection PyTypeChecker
         channel = self._channel  # type: aiormq.Channel
+        channel.on_return_callbacks.remove(self._on_return)
         self._channel = ()
         await channel.close()
 


### PR DESCRIPTION
    This patch fixes problem with unexpected restoration already closed
    channels (after reconnect to the AMQP broker) when the `RobustConnection`
    is being used. The problem is caused by the not freeing reference to the
    `aiopika.Channel._on_return` kept by the `aiormq.Channel.on_return_callbacks`,
    which blocks garbage collector against free a `RobustChannel` object.
