### PR TITLE
Fixed callback on_close for rpc #361

### DIFF
--- a/aio_pika/patterns/rpc.py
+++ b/aio_pika/patterns/rpc.py
@@ -153,7 +153,7 @@ class RPC(Base):
             self.on_message_returned, weak=False,
         )
 
-    def on_close(self, exc=None):
+    def on_close(self, _: Channel, exc: Optional[BaseException] = None):
         log.debug("Closing RPC futures because %r", exc)
         for future in self.futures.values():
             if future.done():


### PR DESCRIPTION
Brief description of the bug:

When we pause the channel from which we instantiate the RPC. A method with an incorrect signature is put into callbacks. Because of this, the following trace occurs:

```
Traceback (most recent call last):
    File \"/usr/local/lib/python3.8/site-packages/aio_pika/tools.py\", line 166, in __call__
        cb(self.__sender(), *args, **kwargs)
        
    TypeError: on_close() takes from 1 to 2 positional arguments but 3 were given
```

Corrected of this issue https://github.com/mosquito/aio-pika/issues/361
Also added a reraise to tools, since the tests did not catch this bug