### PR TITLE
Hotfix/channel writer is none

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -50,9 +50,11 @@ jobs:
           - py37
           - py38
           - py39
+          - py310
           - py36-uvloop
           - py37-uvloop
           - py38-uvloop
+          - py39-uvloop
 
     steps:
       - uses: actions/checkout@v2

--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -189,6 +189,7 @@ class Channel(PoolInstance):
             )
 
         self.channel.on_return_callbacks.add(self._on_return)
+        self.channel.closing.add_done_callback(self._done_callbacks)
 
     def _on_return(self, message: aiormq.types.DeliveredMessage):
         self._return_callbacks(IncomingMessage(message, no_ack=True))

--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -79,7 +79,7 @@ class Channel(PoolInstance):
 
     @property
     def is_closed(self):
-        if not self._channel:
+        if not self._channel or self._is_closed_by_user:
             return True
         return self._channel.is_closed
 

--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -114,7 +114,7 @@ class Channel(PoolInstance):
                 "Channel was not opened"
             )
 
-        if self._channel.is_closed:
+        if self.is_closed:
             raise aiormq.exceptions.ChannelInvalidStateError(
                 "Channel has been closed"
             )

--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -103,6 +103,9 @@ class Channel(PoolInstance):
         if self._channel is None:
             raise RuntimeError("Channel was not opened")
 
+        if self._channel.is_closed:
+            raise RuntimeError("Channel has been closed")
+
         return self._channel
 
     @property

--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -207,7 +207,7 @@ class Connection(PoolInstance):
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         for channel in tuple(self._channels.values()):  # can change size
-            if not channel.is_closed:
+            if channel and not channel.is_closed:
                 await channel.close()
 
         await self.close()

--- a/aio_pika/robust_channel.py
+++ b/aio_pika/robust_channel.py
@@ -77,12 +77,14 @@ class RobustChannel(Channel):
             for queue in queues:
                 await queue.restore(self)
 
-    def _on_channel_close(self, sender, exc: Exception):
+    def _on_channel_close(self, sender, exc: BaseException):
+        if not self._is_closed_by_user:
+            self.loop.create_task(self.reopen())
+
         if exc:
             log.exception(
                 "Robust channel %r has been closed.", sender, exc_info=exc,
             )
-            self.loop.create_task(self.reopen())
             return
 
         log.debug("Robust channel %r has been closed.", sender)

--- a/pylava.ini
+++ b/pylava.ini
@@ -1,6 +1,6 @@
 [pylava]
 ignore=C901,E252
-skip = aio_pika/pika*,env*,.tox*,*build*,.nox*
+skip = env*,.tox*,*build*,.nox*,.venv*,venv*
 
 [pylava:pycodestyle]
 max_line_length = 80

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -1547,6 +1547,9 @@ class TestCaseAmqp(TestCaseAmqpBase):
         # Ensure close callback has been called
         assert close_reasons
 
+        with pytest.raises(RuntimeError):
+            await channel.set_qos(10)
+
 
 class TestCaseAmqpNoConfirms(TestCaseAmqp):
     @staticmethod

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -1539,7 +1539,7 @@ class TestCaseAmqp(TestCaseAmqpBase):
         with pytest.raises(asyncio.TimeoutError):
             await asyncio.wait_for(run(), timeout=0.2)
 
-        with pytest.raises(asyncio.CancelledError):
+        with pytest.raises(RuntimeError):
             await channel.channel.closing
 
         assert channel.is_closed

--- a/tests/test_amqp_robust.py
+++ b/tests/test_amqp_robust.py
@@ -1,3 +1,5 @@
+import asyncio
+import time
 from functools import partial
 
 import pytest
@@ -50,6 +52,38 @@ class TestCaseNoRobust(TestCaseAmqp):
 
         del cb
         assert len(connection.reconnect_callbacks) == 1
+
+    async def test_channel_blocking_timeout_reopen(self, connection):
+        channel = await connection.channel()
+        close_reasons = []
+        reopen_event = asyncio.Event()
+        channel.reopen_callbacks.add(lambda _: reopen_event.set(), weak=False)
+
+        def on_done(*args):
+            close_reasons.append(args)
+            return
+
+        channel.add_close_callback(on_done)
+
+        async def run(sleep_time=1):
+            await channel.set_qos(1)
+            if sleep_time:
+                time.sleep(sleep_time)
+            await channel.set_qos(0)
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(run(), timeout=0.2)
+
+        with pytest.raises(RuntimeError):
+            await channel.channel.closing
+
+        assert channel.is_closed
+
+        # Ensure close callback has been called
+        assert close_reasons
+
+        await asyncio.wait_for(reopen_event.wait(), timeout=2)
+        await asyncio.wait_for(run(sleep_time=0), timeout=2)
 
 
 class TestCaseAmqpNoConfirmsRobust(TestCaseAmqpNoConfirms):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py3{6,7,8,9}{,-uvloop}
+envlist = lint,py3{6,7,8,9}{,-uvloop},py310
 
 [testenv]
 passenv = COVERALLS_* AMQP_*

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = lint,py3{5,6,7},py3{5,6,7}-{uvloop}
+envlist = lint,py3{6,7},py3{6,7}-{uvloop}
 
 [testenv]
 passenv = COVERALLS_* AMQP_*
 
 deps =
-  py35-uvloop: uvloop~=0.14.0
   py36-uvloop: uvloop~=0.14.0
   py37-uvloop: uvloop~=0.15.0
   py37-uvloop: uvloop~=0.15.0
@@ -15,7 +14,7 @@ extras =
   develop
 
 commands=
-  py.test -vv --cov=aio_pika --cov-report=term-missing --doctest-modules --aiomisc-test-timeout=30 tests
+  py.test -sxv --cov=aio_pika --cov-report=term-missing --doctest-modules --aiomisc-test-timeout=30 tests
   - coveralls
 
 [testenv:lint]
@@ -23,7 +22,7 @@ deps =
   pylava
 
 commands=
-  pylava -o pylava.ini .
+  pylava -o pylava.ini aio_pika tests
 
 [testenv:checkdoc]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
-envlist = lint,py3{6,7},py3{6,7}-{uvloop}
+envlist = lint,py3{6,7,8,9}{,-uvloop}
 
 [testenv]
 passenv = COVERALLS_* AMQP_*
 
 deps =
   py36-uvloop: uvloop~=0.14.0
-  py37-uvloop: uvloop~=0.15.0
-  py37-uvloop: uvloop~=0.15.0
-  py37-uvloop: uvloop~=0.15.0
+  py37-uvloop: uvloop~=0.16.0
+  py38-uvloop: uvloop~=0.16.0
+  py39-uvloop: uvloop~=0.16.0
 
 extras =
   develop


### PR DESCRIPTION
If the channel was closed due to a broken RPC, for example due to Cancelled Error, the Robust Channels instance must be reopened.