### PR TITLE
Issue 441 - Suport all versions of python3.6 for poetry

### DIFF
--- a/aio_pika/version.py
+++ b/aio_pika/version.py
@@ -5,7 +5,7 @@ package_license = "Apache Software License"
 
 team_email = "me@mosquito.su"
 
-version_info = (7, 0, 1)
+version_info = (7, 0, 1, 'post0')
 
 __author__ = ", ".join("{} <{}>".format(*info) for info in author_info)
 __version__ = ".".join(map(str, version_info))

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     package_data={"aio_pika": ["py.typed"]},
     install_requires=["aiormq~=6.2.2", "yarl"],
-    python_requires=">3.6, <4",
+    python_requires=">=3.6, <4",
     extras_require={
         "develop": [
             "aiomisc~=15.6.8",


### PR DESCRIPTION
`>3.6` --> `>=3.6`

Use post0 release, since there are no bug fixes or feature changes. Just
making the version requirements less strict. Not strictly SemVer, but
a variant used by PEP 440.