### PR TITLE
📝 Fix logic typo in tutorial

### DIFF
--- a/docs/source/rabbitmq-tutorial/examples/3-publish-subscribe/receive_logs.py
+++ b/docs/source/rabbitmq-tutorial/examples/3-publish-subscribe/receive_logs.py
@@ -28,7 +28,7 @@ async def main() -> None:
         # Binding the queue to the exchange
         await queue.bind(logs_exchange)
 
-        # Start listening the queue with name 'task_queue'
+        # Start listening the queue
         await queue.consume(on_message)
 
         print(" [*] Waiting for logs. To exit press CTRL+C")


### PR DESCRIPTION
In the third tutorial, the comment indicates the name of the declared queue as `"task_queue"`, but in fact the name of the queue is generated randomly.