### PR TITLE
cannot use client_properties issue #468

### DIFF
--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -204,6 +204,7 @@ def make_url(
     virtualhost: str = "/",
     ssl: bool = False,
     ssl_options: dict = None,
+    client_properties: FieldTable = None,
     **kwargs: Any
 ) -> URL:
     if url is not None:
@@ -213,6 +214,7 @@ def make_url(
 
     kw = kwargs
     kw.update(ssl_options or {})
+    kw.update(client_properties or {})
 
     # sanitize keywords
     kw = {k: v for k, v in kw.items() if v is not None}


### PR DESCRIPTION
fix for issue #468 :

The problem seems to be the refactoring of the connect/connect_robust method. 

Now it passes the client_properties to make_url() which does not expect it, thus is becomes kwargs.
```
make_url(... **kwargs):
...
kw = kwargs # <- {'client_properties': {'connection_name': 'A writer connection'}}`
...
return URL.build(
        ....
        query=kw)
```

yarl url.build should get  {'connection_name': 'A writer connection'}, not {'client_properties': {'connection_name': 'A writer connection'}}

The fix is, imho to add client_properties to the make_url arguments, and merge it with kw (similarly to the ssl_options).