### PR TITLE
Fix memory leaks on channel close

### DIFF
--- a/aio_pika/abc.py
+++ b/aio_pika/abc.py
@@ -461,7 +461,7 @@ class UnderlayChannel(NamedTuple):
             return
 
         # close callbacks must be fired when closing
-        # and should be deleted later for prevent memory leaks
+        # and should be deleted later to prevent memory leaks
         await self.channel.close(exc)
         await self.close_callback.wait()
 

--- a/aio_pika/abc.py
+++ b/aio_pika/abc.py
@@ -462,15 +462,13 @@ class UnderlayChannel(NamedTuple):
 
         # close callbacks must be fired when closing
         # and should be deleted later for prevent memory leaks
-        result: Any = await self.channel.close(exc)
+        await self.channel.close(exc)
         await self.close_callback.wait()
 
         self.channel.closing.remove_done_callback(self.close_callback)
         self.channel.connection.closing.remove_done_callback(
             self.close_callback
         )
-
-        return result
 
 
 class AbstractChannel(PoolInstance, ABC):


### PR DESCRIPTION
Fixes #490 

`leaks_test.py`
```python
import asyncio
import logging

import aiomisc
from aiomisc.service.tracer import MemoryTracer
from aio_pika import connect_robust


async def main():
    logging.basicConfig(level=logging.DEBUG)

    counter = 0
    while True:
        connect = await connect_robust()
        channel = await connect.channel()
        await asyncio.sleep(0.001)
        await channel.close()
        await connect.close()
        counter += 1

        if not counter % 100:
            logging.info("%d Connections done", counter)


aiomisc.run(main(), MemoryTracer(), log_format="rich")
```