### PR TITLE
Prevent "Task exception was never retrieved" on timeout

### DIFF
--- a/aio_pika/tools.py
+++ b/aio_pika/tools.py
@@ -42,6 +42,7 @@ def _task_done(future: asyncio.Future) -> None:
     if exc is not None:
         raise exc
 
+
 def create_task(
     func: Callable[..., Union[Coroutine[Any, Any, T], Awaitable[T]]],
     *args: Any,

--- a/aio_pika/tools.py
+++ b/aio_pika/tools.py
@@ -37,6 +37,11 @@ def iscoroutinepartial(fn: Callable[..., Any]) -> bool:
     return asyncio.iscoroutinefunction(parent)
 
 
+def _task_done(future: asyncio.Future) -> None:
+    exc = future.exception()
+    if exc is not None:
+        raise exc
+
 def create_task(
     func: Callable[..., Union[Coroutine[Any, Any, T], Awaitable[T]]],
     *args: Any,
@@ -44,11 +49,6 @@ def create_task(
     **kwargs: Any
 ) -> Awaitable[T]:
     loop = loop or asyncio.get_event_loop()
-
-    def _task_done(future: asyncio.Future) -> None:
-        exc = future.exception()
-        if exc:
-            raise exc
 
     if iscoroutinepartial(func):
         task = loop.create_task(func(*args, **kwargs))      # type: ignore


### PR DESCRIPTION
Sometimes we have an issue with RabbitMQ in production, and we see a lot of these types of errors:

<img width="1421" alt="image" src="https://user-images.githubusercontent.com/439758/191273049-a2c05962-f30a-4cf0-8505-65e493195fd7.png">

This appears to be caused by some task objects that are missing a done_callback. This in turn could cause exceptions to be swallowed, I **think**.

I wonder if something like this could fix it.