### PR TITLE
Remove loop from examples

### DIFF
--- a/docs/source/examples/master.py
+++ b/docs/source/examples/master.py
@@ -27,5 +27,4 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    asyncio.run(main())


### PR DESCRIPTION
Application developers should typically use the high-level asyncio functions, such as `asyncio.run()`, and should rarely need to reference the `loop` object or call its methods