### PR TITLE
Fix memory leaks

### DIFF
--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -184,6 +184,9 @@ class Channel(ChannelContext):
     async def _on_close(self, closing: asyncio.Future) -> None:
         await self.close_callbacks(closing.exception())
 
+        if self._channel and self._channel.channel:
+            self._channel.channel.on_return_callbacks.discard(self._on_return)
+
     async def _on_initialized(self) -> None:
         self.channel.on_return_callbacks.add(self._on_return)
 

--- a/aio_pika/robust_channel.py
+++ b/aio_pika/robust_channel.py
@@ -68,6 +68,7 @@ class RobustChannel(Channel, AbstractRobustChannel):    # type: ignore
 
     async def __close_callback(self, *_: Any) -> None:
         if self._closed or self._connection.is_closed:
+            self.close_callbacks.discard(self.__close_callback)
             return
 
         await self.reopen()

--- a/tests/test_memory_leak.py
+++ b/tests/test_memory_leak.py
@@ -1,12 +1,9 @@
 import gc
 import weakref
 
-import pytest
-
 import aio_pika
 
 
-@pytest.mark.skip(reason="temporary skipped")
 async def test_leak_unclosed_channel(create_connection):
     rabbitmq_connection = await create_connection()
 
@@ -24,7 +21,6 @@ async def test_leak_unclosed_channel(create_connection):
     assert len(tuple(weakset)) == 0
 
 
-@pytest.mark.skip(reason="temporary skipped")
 async def test_leak_closed_channel(create_connection):
     rabbitmq_connection = await create_connection()
 


### PR DESCRIPTION
I've found two places that keep references to the Channel object methods and that prevents `Garbage Collecter` from deleting the channel from the memory. As result, after restoring the connection the `RobustConnection` restores all already closed channels.

The issue reproduction steps:
1. Start locally RabbitMQ broker instance
2. Create RobustConnection to the broker and open some RobustChannel
3. Check in a panel (i.e. RabbitMQ management) that the channel is opened
4. Close the channel
5. Restart broker
6. Check that you already opened 2 channels