### PR TITLE
Fix timeout logging on QueueIterator

### DIFF
--- a/aio_pika/queue.py
+++ b/aio_pika/queue.py
@@ -458,7 +458,7 @@ class QueueIterator(AbstractQueueIterator):
             )
         except asyncio.CancelledError:
             timeout = self._consume_kwargs.get(
-                "timeout", 
+                "timeout",
                 self.DEFAULT_CLOSE_TIMEOUT,
             )
             log.info(

--- a/aio_pika/queue.py
+++ b/aio_pika/queue.py
@@ -457,15 +457,15 @@ class QueueIterator(AbstractQueueIterator):
                 timeout=self._consume_kwargs.get("timeout"),
             )
         except asyncio.CancelledError:
+            timeout = self._consume_kwargs.get(
+                "timeout", 
+                self.DEFAULT_CLOSE_TIMEOUT,
+            )
             log.info(
                 "%r closing with timeout %d seconds",
-                self, self.DEFAULT_CLOSE_TIMEOUT,
+                self, timeout,
             )
-            await asyncio.wait_for(
-                self.close(), timeout=self._consume_kwargs.get(
-                    "timeout", self.DEFAULT_CLOSE_TIMEOUT,
-                ),
-            )
+            await asyncio.wait_for(self.close(), timeout=timeout)
             raise
 
 


### PR DESCRIPTION
A wrong information (the default timeout) is being printed (instead of the supplied one in kwargs).