### PR TITLE
Fix getting futures exceptions

### DIFF
--- a/aio_pika/channel.py
+++ b/aio_pika/channel.py
@@ -182,7 +182,11 @@ class Channel(ChannelContext):
         )
 
     async def _on_close(self, closing: asyncio.Future) -> None:
-        await self.close_callbacks(closing.exception())
+        try:
+            exc = closing.exception()
+        except asyncio.CancelledError as e:
+            exc = e
+        await self.close_callbacks(exc)
 
         if self._channel and self._channel.channel:
             self._channel.channel.on_return_callbacks.discard(self._on_return)

--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -75,7 +75,10 @@ class Connection(AbstractConnection):
         return f'<{self.__class__.__name__}: "{self}">'
 
     async def _on_connection_close(self, closing: asyncio.Future) -> None:
-        exc: Optional[BaseException] = closing.exception()
+        try:
+            exc = closing.exception()
+        except asyncio.CancelledError as e:
+            exc = e
         self.connected.clear()
         await self.close_callbacks(exc)
 

--- a/aio_pika/tools.py
+++ b/aio_pika/tools.py
@@ -38,9 +38,10 @@ def iscoroutinepartial(fn: Callable[..., Any]) -> bool:
 
 
 def _task_done(future: asyncio.Future) -> None:
-    exc = future.exception()
-    if exc is not None:
-        raise exc
+    if not future.cancelled():
+        exc = future.exception()
+        if exc is not None:
+            raise exc
 
 
 def create_task(


### PR DESCRIPTION
Access to `asyncio.Future.exception()` should be protected from unexpected raise of `asyncio.CancelledError` exception.