### PR TITLE
Do not nack if consumer is no_ack in QueueIterator

### DIFF
--- a/aio_pika/queue.py
+++ b/aio_pika/queue.py
@@ -416,7 +416,7 @@ class QueueIterator(AbstractQueueIterator):
 
             if self._consume_kwargs.get("no_ack", False):
                 log.warning(
-                    "Message %r lost for consumer with no_ack",
+                    "Message %r lost for consumer with no_ack %r",
                     msg,
                     self,
                 )

--- a/aio_pika/queue.py
+++ b/aio_pika/queue.py
@@ -403,13 +403,27 @@ class QueueIterator(AbstractQueueIterator):
             while True:
                 msg = self._queue.get_nowait()
         except asyncio.QueueEmpty:
-            nack_ok = (
-                msg is not None
-                and not self._amqp_queue.channel.is_closed
-                and not self._consume_kwargs.get("no_ack", False)
-            )
-            if nack_ok:
-                await msg.nack(requeue=True, multiple=True)
+            if msg is None:
+                return
+
+            if self._amqp_queue.channel.is_closed:
+                log.warning(
+                    "Message %r lost when queue iterator %r channel closed",
+                    msg,
+                    self,
+                )
+                return
+
+            if self._consume_kwargs.get("no_ack", False):
+                log.warning(
+                    "Message %r lost for consumer with no_ack",
+                    msg,
+                    self,
+                )
+                return
+
+            await msg.nack(requeue=True, multiple=True)
+
 
     def __str__(self) -> str:
         return f"queue[{self._amqp_queue}](...)"

--- a/aio_pika/queue.py
+++ b/aio_pika/queue.py
@@ -424,7 +424,6 @@ class QueueIterator(AbstractQueueIterator):
 
             await msg.nack(requeue=True, multiple=True)
 
-
     def __str__(self) -> str:
         return f"queue[{self._amqp_queue}](...)"
 

--- a/aio_pika/queue.py
+++ b/aio_pika/queue.py
@@ -403,7 +403,12 @@ class QueueIterator(AbstractQueueIterator):
             while True:
                 msg = self._queue.get_nowait()
         except asyncio.QueueEmpty:
-            if msg is not None and not self._amqp_queue.channel.is_closed:
+            nack_ok = (
+                msg is not None
+                and not self._amqp_queue.channel.is_closed
+                and not self._consume_kwargs.get("no_ack", False)
+            )
+            if nack_ok:
                 await msg.nack(requeue=True, multiple=True)
 
     def __str__(self) -> str:


### PR DESCRIPTION
An exception is raised if `QueueIterator` is created with the consumer flag `no_ack`.
Added a check to ensure `nack` is not getting called when `QeueuIterator` is closed and `consumer` has `no_ack` option set to `True`.