### PR TITLE
Prevent 'Task exception was never retrieved'

### DIFF
--- a/aio_pika/tools.py
+++ b/aio_pika/tools.py
@@ -38,10 +38,12 @@ def iscoroutinepartial(fn: Callable[..., Any]) -> bool:
 
 
 def _task_done(future: asyncio.Future) -> None:
-    if not future.cancelled():
+    try:
         exc = future.exception()
         if exc is not None:
             raise exc
+    except asyncio.CancelledError:
+        pass
 
 
 def create_task(


### PR DESCRIPTION
If future.exception() is not called (even on cancelled futures), it seems Python will then log 'Task exception was never retrieved'. Rewriting this logic slightly should hopefully achieve the same functionality while preventing the Python errors.