### PR TITLE
Avoid implicitly depending on setuptools

### DIFF
--- a/aio_pika/__init__.py
+++ b/aio_pika/__init__.py
@@ -1,5 +1,3 @@
-from pkg_resources import get_distribution
-
 from . import abc, patterns, pool
 from .abc import DeliveryMode
 from .channel import Channel
@@ -15,7 +13,12 @@ from .robust_exchange import RobustExchange
 from .robust_queue import RobustQueue
 
 
-__version__ = get_distribution("aio-pika").version
+try:
+    from importlib.metadata import Distribution
+    __version__ = Distribution.from_name("aio-pika").version
+except ImportError:
+    import pkg_resources
+    __version__ = pkg_resources.get_distribution("aio-pika").version
 
 
 __all__ = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,11 @@ packages = [{ include = "aio_pika" }]
 
 [tool.poetry.dependencies]
 python = "^3.7"
-aiormq= "~6.7.1"
+aiormq = "~6.7.1"
 yarl = [{ version = '*'}]
 typing_extensions = [{ version = '*', python = "< 3.8" }]
+# for pkg_resources
+setuptools = [{ version = '*', python = "< 3.8" }]
 
 [tool.poetry.group.dev.dependencies]
 aiomisc = "^16.2"


### PR DESCRIPTION
Currently there's an implicit dependency on `pkg_resources` from `setuptools` to get the version of the package.  This makes the dependency explicit for Python 3.7 and avoids it entirely for 3.8+ which have `importlib.metadata` available.
