### PR TITLE
Update example code of rpc tutorial

### DIFF
--- a/docs/source/rabbitmq-tutorial/examples/6-rpc/rpc_client.py
+++ b/docs/source/rabbitmq-tutorial/examples/6-rpc/rpc_client.py
@@ -24,7 +24,7 @@ class FibonacciRpcClient:
         )
         self.channel = await self.connection.channel()
         self.callback_queue = await self.channel.declare_queue(exclusive=True)
-        await self.callback_queue.consume(self.on_response)
+        await self.callback_queue.consume(self.on_response, no_ack=True)
 
         return self
 


### PR DESCRIPTION
Change to automatically handle acks of queues expecting rpc responses.

If the no_ack flag is False, the task resource is not removed from rabbitmq because the ack of the response message is not processed. The reason why explicit ack was not used is that there is no queue waiting for the ack of response.