### PR TITLE
bugfix: kwargs not working in aio_pika connect_robust

### DIFF
--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -360,7 +360,9 @@ async def connect(
             client_properties=client_properties,
             **kwargs,
         ),
-        loop=loop, ssl_context=ssl_context,
+        loop=loop,
+        ssl_context=ssl_context,
+        **kwargs,
     )
 
     await connection.connect(timeout=timeout)

--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -320,7 +320,7 @@ async def connect_robust(
             client_properties=client_properties,
             **kwargs,
         ),
-        loop=loop, ssl_context=ssl_context,
+        loop=loop, ssl_context=ssl_context, **kwargs
     )
 
     await connection.connect(timeout=timeout)

--- a/tests/test_kwargs.py
+++ b/tests/test_kwargs.py
@@ -1,7 +1,6 @@
 from aiormq.connection import parse_bool, parse_int, parse_timeout
 
 from aio_pika import connect
-from aio_pika.abc import AbstractConnection
 from aio_pika.connection import Connection
 from aio_pika.robust_connection import RobustConnection, connect_robust
 

--- a/tests/test_kwargs.py
+++ b/tests/test_kwargs.py
@@ -80,6 +80,6 @@ class TestCaseRobust(TestCase):
     async def get_instance(self, url, **kwargs):
         return await connect_robust(
             url,
-            connection_class=self.CONNECTION_CLASS,
-            **kwargs,  # type: ignore
+            connection_class=self.CONNECTION_CLASS,  # type: ignore
+            **kwargs,
         )

--- a/tests/test_kwargs.py
+++ b/tests/test_kwargs.py
@@ -46,7 +46,9 @@ class TestCase:
     CONNECTION_CLASS = MockConnection
 
     async def get_instance(self, url, **kwargs):
-        return await connect(url, connection_class=self.CONNECTION_CLASS, **kwargs)
+        return await connect(
+            url, connection_class=self.CONNECTION_CLASS, **kwargs
+        )
 
     async def test_kwargs(self):
         instance = await self.get_instance("amqp://localhost/")
@@ -59,11 +61,15 @@ class TestCase:
         for key, parser, default in self.CONNECTION_CLASS.KWARGS_TYPES:
             positives = VALUE_GENERATORS[parser]  # type: ignore
             for example, expected in positives.items():  # type: ignore
-                instance = await self.get_instance(f"amqp://localhost/?{key}={example}")
+                instance = await self.get_instance(
+                    f"amqp://localhost/?{key}={example}"
+                )
                 assert hasattr(instance, key)
                 assert getattr(instance, key) == expected
 
-                instance = await self.get_instance("amqp://localhost", **{key: example})
+                instance = await self.get_instance(
+                    "amqp://localhost", **{key: example}
+                )
                 assert hasattr(instance, key)
                 assert getattr(instance, key) == expected
 

--- a/tests/test_kwargs.py
+++ b/tests/test_kwargs.py
@@ -79,5 +79,7 @@ class TestCaseRobust(TestCase):
 
     async def get_instance(self, url, **kwargs):
         return await connect_robust(
-            url, connection_class=self.CONNECTION_CLASS, **kwargs  # type: ignore
+            url,
+            connection_class=self.CONNECTION_CLASS,
+            **kwargs,  # type: ignore
         )

--- a/tests/test_kwargs.py
+++ b/tests/test_kwargs.py
@@ -2,7 +2,7 @@ from aiormq.connection import parse_bool, parse_int, parse_timeout
 
 from aio_pika import connect
 from aio_pika.connection import Connection
-from aio_pika.robust_connection import RobustConnection
+from aio_pika.robust_connection import RobustConnection, connect_robust
 
 
 class MockConnection(Connection):
@@ -70,3 +70,8 @@ class TestCase:
 
 class TestCaseRobust(TestCase):
     CONNECTION_CLASS = MockConnectionRobust  # type: ignore
+
+    async def get_instance(self, url, **kwargs):
+        return await connect_robust(
+            url, connection_class=self.CONNECTION_CLASS, **kwargs
+        )

--- a/tests/test_kwargs.py
+++ b/tests/test_kwargs.py
@@ -1,6 +1,7 @@
 from aiormq.connection import parse_bool, parse_int, parse_timeout
 
 from aio_pika import connect
+from aio_pika.abc import AbstractConnection
 from aio_pika.connection import Connection
 from aio_pika.robust_connection import RobustConnection, connect_robust
 
@@ -79,5 +80,5 @@ class TestCaseRobust(TestCase):
 
     async def get_instance(self, url, **kwargs):
         return await connect_robust(
-            url, connection_class=self.CONNECTION_CLASS, **kwargs
+            url, connection_class=self.CONNECTION_CLASS, **kwargs  # type: ignore
         )


### PR DESCRIPTION
I provide a fix, so that the kwargs are passed down through connection_class in aio_pika.connect_robust().

In current master branch specifying fail_fast has no effect and the default values are used.

Following code will fail on master branch:
```
import asyncio
import aio_pika

async def main():
    con = await aio_pika.connect_robust(fail_fast="False")
    async with con:
        assert con.fail_fast == False

asyncio.run(main())
```

This PR fixes connect() and connect_robust() and extends and fixes the existing unit tests.