### PR TITLE
Queue.declare() passive parameter not recognized

### DIFF
--- a/aio_pika/queue.py
+++ b/aio_pika/queue.py
@@ -66,7 +66,7 @@ class Queue(AbstractQueue):
         )
 
     async def declare(
-        self, timeout: TimeoutType = None,
+        self, timeout: TimeoutType = None, passive: Optional[bool] = None
     ) -> aiormq.spec.Queue.DeclareOk:
         """ Declare queue.
 
@@ -81,7 +81,7 @@ class Queue(AbstractQueue):
             exclusive=self.exclusive,
             auto_delete=self.auto_delete,
             arguments=self.arguments,
-            passive=self.passive,
+            passive=passive or self.passive,
             timeout=timeout,
         )
 


### PR DESCRIPTION
In the `Queue` class the Function `declare` takes an argument called `passive` according to docstrings.
Currently it does not.
This PR adds it as an optional parameter.
if no argument is given it will default to `self.passive`