### PR TITLE
Improve type hints for queue.get()

### DIFF
--- a/aio_pika/abc.py
+++ b/aio_pika/abc.py
@@ -1,5 +1,6 @@
 import asyncio
 import dataclasses
+import sys
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta
 from enum import Enum, IntEnum, unique
@@ -7,14 +8,13 @@ from functools import singledispatch
 from types import TracebackType
 from typing import (
     Any, AsyncContextManager, AsyncIterable, Awaitable, Callable, Dict,
-    Generator, Iterator, Optional, Type, TypeVar, Union,
+    Generator, Iterator, Optional, Type, TypeVar, Union, overload,
 )
 
-
-try:
-    from typing import TypedDict
-except ImportError:
-    from typing_extensions import TypedDict
+if sys.version_info >= (3, 8):
+    from typing import Literal, TypedDict
+else:
+    from typing_extensions import Literal, TypedDict
 
 import aiormq.abc
 from aiormq.abc import ExceptionType
@@ -324,6 +324,18 @@ class AbstractQueue:
     ) -> aiormq.spec.Basic.CancelOk:
         raise NotImplementedError
 
+    @overload
+    async def get(
+        self, *, no_ack: bool = False,
+        fail: Literal[True] = ..., timeout: TimeoutType = ...,
+    ) -> AbstractIncomingMessage:
+        ...
+    @overload
+    async def get(
+        self, *, no_ack: bool = False,
+        fail: Literal[False] = ..., timeout: TimeoutType = ...,
+    ) -> Optional[AbstractIncomingMessage]:
+        ...
     @abstractmethod
     async def get(
         self, *, no_ack: bool = False,

--- a/aio_pika/abc.py
+++ b/aio_pika/abc.py
@@ -330,12 +330,14 @@ class AbstractQueue:
         fail: Literal[True] = ..., timeout: TimeoutType = ...,
     ) -> AbstractIncomingMessage:
         ...
+
     @overload
     async def get(
         self, *, no_ack: bool = False,
         fail: Literal[False] = ..., timeout: TimeoutType = ...,
     ) -> Optional[AbstractIncomingMessage]:
         ...
+
     @abstractmethod
     async def get(
         self, *, no_ack: bool = False,

--- a/aio_pika/queue.py
+++ b/aio_pika/queue.py
@@ -1,7 +1,8 @@
 import asyncio
+import sys
 from functools import partial
 from types import TracebackType
-from typing import Any, Callable, Optional, Type
+from typing import Any, Callable, Optional, Type, overload
 
 import aiormq
 from aiormq.abc import DeliveredMessage
@@ -16,6 +17,12 @@ from .exchange import ExchangeParamType
 from .log import get_logger
 from .message import IncomingMessage
 from .tools import CallbackCollection, create_task
+
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 log = get_logger(__name__)
@@ -256,6 +263,18 @@ class Queue(AbstractQueue):
             consumer_tag=consumer_tag, nowait=nowait, timeout=timeout,
         )
 
+    @overload
+    async def get(
+        self, *, no_ack: bool = False,
+        fail: Literal[True] = ..., timeout: TimeoutType = ...,
+    ) -> IncomingMessage:
+        ...
+    @overload
+    async def get(
+        self, *, no_ack: bool = False,
+        fail: Literal[False] = ..., timeout: TimeoutType = ...,
+    ) -> Optional[IncomingMessage]:
+        ...
     async def get(
         self, *, no_ack: bool = False,
         fail: bool = True, timeout: TimeoutType = 5,

--- a/aio_pika/queue.py
+++ b/aio_pika/queue.py
@@ -276,7 +276,7 @@ class Queue(AbstractQueue):
         fail: Literal[False] = ..., timeout: TimeoutType = ...,
     ) -> Optional[IncomingMessage]:
         ...
-[]
+
     async def get(
         self, *, no_ack: bool = False,
         fail: bool = True, timeout: TimeoutType = 5,

--- a/aio_pika/queue.py
+++ b/aio_pika/queue.py
@@ -269,12 +269,14 @@ class Queue(AbstractQueue):
         fail: Literal[True] = ..., timeout: TimeoutType = ...,
     ) -> IncomingMessage:
         ...
+
     @overload
     async def get(
         self, *, no_ack: bool = False,
         fail: Literal[False] = ..., timeout: TimeoutType = ...,
     ) -> Optional[IncomingMessage]:
         ...
+[]
     async def get(
         self, *, no_ack: bool = False,
         fail: bool = True, timeout: TimeoutType = 5,


### PR DESCRIPTION
The master assumes that the message should be checked for not-none even if `fail=True` (default) and None is never returned.
```
msg = await queue.get()
assert msg is not None
```

The proposal avoids the need for such asserts by using `typing.Literal` and method overloads.