### PR TITLE
Add `See also` section (#557)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -314,3 +314,5 @@ Changes should follow a few simple rules:
 .. _Semantic Versioning: http://semver.org/
 .. _aio-pika: https://github.com/mosquito/aio-pika/
 .. _propan: https://github.com/Lancetnik/Propan
+.. _patio: https://github.com/patio-python/patio
+.. _patio-rmq: https://github.com/patio-python/patio-rabbitmq

--- a/README.rst
+++ b/README.rst
@@ -211,6 +211,30 @@ Get single message example:
 
 There are more examples and the RabbitMQ tutorial in the `documentation`_.
 
+See also
+==========
+
+`Propan`_ :fire:
+------
+
+**Propan** is a powerful and easy-to-use Python framework for building event-driven applications that interact with any MQ Broker.
+
+**Propan** provides you with the ability to use high-level interfaces to declare handlers, validate messages by **pydantic**, generate your project **AsyncAPI** spec, test it locally, and more.
+
+In fact, it is a high-level wrapper on top of **aio-pika**, so you can use both of these libraries' advantages at the same time.
+
+**Propan** RabbiMQ hello-world example:
+
+.. code-block:: python
+
+   from propan import PropanApp, RabbitBroker
+   
+   broker = RabbitBroker("amqp://guest:guest@localhost:5672/")
+   app = PropanApp(broker)
+   
+   @broker.handle("user")
+   async def user_created(user_id: int):
+       assert isinstance(user_id, int)
 
 Versioning
 ==========
@@ -289,3 +313,4 @@ Changes should follow a few simple rules:
 .. _"thank's to" section: https://github.com/mosquito/aio-pika/blob/master/docs/source/index.rst#thanks-for-contributing
 .. _Semantic Versioning: http://semver.org/
 .. _aio-pika: https://github.com/mosquito/aio-pika/
+.. _propan: https://github.com/Lancetnik/Propan

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
 .. _documentation: https://aio-pika.readthedocs.org/
 .. _adopted official RabbitMQ tutorial: https://aio-pika.readthedocs.io/en/latest/rabbitmq-tutorial/1-introduction.html
 
+
 aio-pika
 ========
 
@@ -214,8 +215,8 @@ There are more examples and the RabbitMQ tutorial in the `documentation`_.
 See also
 ==========
 
-`aiormq`_
----------
+`aiormq <https://github.com/mosquito/aiormq>`_
+----------------------------------------------
 
 `aiormq` is a pure python AMQP client library. It is under the hood of **aio-pika** and might to be used when you really loving works with the protocol low level.
 Following examples demonstrates the user API.
@@ -530,7 +531,6 @@ Changes should follow a few simple rules:
 .. _Semantic Versioning: http://semver.org/
 .. _aio-pika: https://github.com/mosquito/aio-pika/
 .. _propan: https://github.com/Lancetnik/Propan
-.. _aiormq: https://github.com/mosquito/aiormq
 .. _patio: https://github.com/patio-python/patio
 .. _patio-rabbitmq: https://github.com/patio-python/patio-rabbitmq
 .. _Socket.IO: https://socket.io/

--- a/README.rst
+++ b/README.rst
@@ -223,7 +223,7 @@ If you need no deep dive into **RabbitMQ** details, you can use more high-level 
 
 .. code-block:: python
 
-   from propane import Propaneapp, Rabbit Broker
+   from propane import Propaneapp, RabbitBroker
    
    broker = RabbitBroker("amqp://guest:guest@localhost:5672/")
    app = Propane app(broker)

--- a/README.rst
+++ b/README.rst
@@ -214,27 +214,27 @@ There are more examples and the RabbitMQ tutorial in the `documentation`_.
 See also
 ==========
 
-`Propan`_ :fire:
+`Propan`_:fire:
 ------
 
 **Propan** is a powerful and easy-to-use Python framework for building event-driven applications that interact with any MQ Broker.
 
-**Propan** provides you with the ability to use high-level interfaces to declare handlers, validate messages by **pydantic**, generate your project **AsyncAPI** spec, test it locally, and more.
-
-In fact, it is a high-level wrapper on top of **aio-pika**, so you can use both of these libraries' advantages at the same time.
-
-**Propan** RabbiMQ hello-world example:
+If you need no deep dive into **RabbitMQ** details, you can use more high-level **Propan** interfaces:
 
 .. code-block:: python
 
-   from propan import PropanApp, RabbitBroker
+   from propane import Propaneapp, Rabbit Broker
    
    broker = RabbitBroker("amqp://guest:guest@localhost:5672/")
-   app = PropanApp(broker)
+   app = Propane app(broker)
    
    @broker.handle("user")
    async def user_created(user_id: int):
        assert isinstance(user_id, int)
+
+Also, **Propan** validates messages by **pydantic**, generates your project **AsyncAPI** spec, tests application locally, and more.
+
+In fact, it is a high-level wrapper on top of **aio-pika**, so you can use both of these libraries' advantages at the same time.
 
 Versioning
 ==========

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -192,16 +192,27 @@ Thanks for contributing
 See also
 ==========
 
-`Propan`_ :fire:
+`Propan`_:fire:
 ------
 
 **Propan** is a powerful and easy-to-use Python framework for building event-driven applications that interact with any MQ Broker.
 
-**Propan** provides you with the ability to use high-level interfaces to declare handlers, validate messages by **pydantic**, generate your project **AsyncAPI** spec, test it locally, and more.
+If you need no deep dive into **RabbitMQ** details, you can use more high-level **Propan** interfaces:
+
+.. code-block:: python
+
+   from propane import Propaneapp, Rabbit Broker
+   
+   broker = RabbitBroker("amqp://guest:guest@localhost:5672/")
+   app = Propane app(broker)
+   
+   @broker.handle("user")
+   async def user_created(user_id: int):
+       assert isinstance(user_id, int)
+
+Also, **Propan** validates messages by **pydantic**, generates your project **AsyncAPI** spec, tests application locally, and more.
 
 In fact, it is a high-level wrapper on top of **aio-pika**, so you can use both of these libraries' advantages at the same time.
-
-**Propan** RabbiMQ hello-world example:
 
 Versioning
 ==========
@@ -210,3 +221,4 @@ This software follows `Semantic Versioning`_
 
 
 .. _Semantic Versioning: http://semver.org/
+.. _propan: https://github.com/Lancetnik/Propan

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -201,7 +201,7 @@ If you need no deep dive into **RabbitMQ** details, you can use more high-level 
 
 .. code-block:: python
 
-   from propane import Propaneapp, Rabbit Broker
+   from propane import Propaneapp, RabbitBroker
    
    broker = RabbitBroker("amqp://guest:guest@localhost:5672/")
    app = Propane app(broker)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -189,6 +189,20 @@ Thanks for contributing
 .. _@dizballanze: https://github.com/dizballanze
 
 
+See also
+==========
+
+`Propan`_ :fire:
+------
+
+**Propan** is a powerful and easy-to-use Python framework for building event-driven applications that interact with any MQ Broker.
+
+**Propan** provides you with the ability to use high-level interfaces to declare handlers, validate messages by **pydantic**, generate your project **AsyncAPI** spec, test it locally, and more.
+
+In fact, it is a high-level wrapper on top of **aio-pika**, so you can use both of these libraries' advantages at the same time.
+
+**Propan** RabbiMQ hello-world example:
+
 Versioning
 ==========
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -248,3 +248,5 @@ This software follows `Semantic Versioning`_
 
 .. _Semantic Versioning: http://semver.org/
 .. _propan: https://github.com/Lancetnik/Propan
+.. _patio: https://github.com/patio-python/patio
+.. _patio-rmq: https://github.com/patio-python/patio-rabbitmq

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -192,8 +192,34 @@ Thanks for contributing
 See also
 ==========
 
+`Patio`_ and `Patio-RMQ`_
+-------------------------
+
+**PATIO** is an acronym for Python Asynchronous Tasks for AsyncIO - an easily extensible library, for distributed task execution, like celery, only targeting asyncio as the main design approach.
+
+**Patio-RMQ** provides you with the ability to use *RPC over RabbitMQ* services with extremely simple implementation:
+
+.. code-block:: python
+
+   from patio import Registry, ThreadPoolExecutor
+   from patio_rabbitmq import RabbitMQBroker
+
+   rpc = Registry(project="patio-rabbitmq", auto_naming=False)
+   
+   @rpc("sum")
+   def sum(*args):
+       return sum(args)
+
+   async def main():
+       async with ThreadPoolExecutor(rpc, max_workers=16) as executor:
+           async with RabbitMQBroker(
+               executor, amqp_url="amqp://guest:guest@localhost/",
+           ) as broker:
+               await broker.join()
+
+
 `Propan`_:fire:
-------
+---------------
 
 **Propan** is a powerful and easy-to-use Python framework for building event-driven applications that interact with any MQ Broker.
 
@@ -210,7 +236,7 @@ If you need no deep dive into **RabbitMQ** details, you can use more high-level 
    async def user_created(user_id: int):
        assert isinstance(user_id, int)
 
-Also, **Propan** validates messages by **pydantic**, generates your project **AsyncAPI** spec, tests application locally, and more.
+Also, **Propan** validates messages by **pydantic**, generates your project **AsyncAPI** spec, tests application locally, RPC calls, and more.
 
 In fact, it is a high-level wrapper on top of **aio-pika**, so you can use both of these libraries' advantages at the same time.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -192,12 +192,90 @@ Thanks for contributing
 See also
 ==========
 
-`Patio`_ and `Patio-RMQ`_
--------------------------
+`aiormq <https://github.com/mosquito/aiormq>`_
+----------------------------------------------
+
+`aiormq` is a pure python AMQP client library. It is under the hood of **aio-pika** and might to be used when you really loving works with the protocol low level.
+Following examples demonstrates the user API.
+
+Simple consumer:
+
+.. code-block:: python
+
+    import asyncio
+    import aiormq
+
+    async def on_message(message):
+        """
+        on_message doesn't necessarily have to be defined as async.
+        Here it is to show that it's possible.
+        """
+        print(f" [x] Received message {message!r}")
+        print(f"Message body is: {message.body!r}")
+        print("Before sleep!")
+        await asyncio.sleep(5)   # Represents async I/O operations
+        print("After sleep!")
+
+    async def main():
+        # Perform connection
+        connection = await aiormq.connect("amqp://guest:guest@localhost/")
+
+        # Creating a channel
+        channel = await connection.channel()
+
+        # Declaring queue
+        declare_ok = await channel.queue_declare('helo')
+        consume_ok = await channel.basic_consume(
+            declare_ok.queue, on_message, no_ack=True
+        )
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())
+    loop.run_forever()
+
+Simple publisher:
+
+.. code-block:: python
+
+    import asyncio
+    from typing import Optional
+
+    import aiormq
+    from aiormq.abc import DeliveredMessage
+
+    MESSAGE: Optional[DeliveredMessage] = None
+
+    async def main():
+        global MESSAGE
+        body = b'Hello World!'
+
+        # Perform connection
+        connection = await aiormq.connect("amqp://guest:guest@localhost//")
+
+        # Creating a channel
+        channel = await connection.channel()
+        declare_ok = await channel.queue_declare("hello", auto_delete=True)
+
+        # Sending the message
+        await channel.basic_publish(body, routing_key='hello')
+        print(f" [x] Sent {body}")
+
+        MESSAGE = await channel.basic_get(declare_ok.queue)
+        print(f" [x] Received message from {declare_ok.queue!r}")
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())
+
+    assert MESSAGE is not None
+    assert MESSAGE.routing_key == "hello"
+    assert MESSAGE.body == b'Hello World!'
+
+The `patio`_ and the `patio-rabbitmq`_
+--------------------------------------
 
 **PATIO** is an acronym for Python Asynchronous Tasks for AsyncIO - an easily extensible library, for distributed task execution, like celery, only targeting asyncio as the main design approach.
 
-**Patio-RMQ** provides you with the ability to use *RPC over RabbitMQ* services with extremely simple implementation:
+**patio-rabbitmq** provides you with the ability to use *RPC over RabbitMQ* services with extremely simple implementation:
 
 .. code-block:: python
 
@@ -217,6 +295,25 @@ See also
            ) as broker:
                await broker.join()
 
+And the caller side might be written like this:
+
+.. code-block:: python
+
+    import asyncio
+    from patio import NullExecutor, Registry
+    from patio_rabbitmq import RabbitMQBroker
+
+    async def main():
+        async with NullExecutor(Registry(project="patio-rabbitmq")) as executor:
+            async with RabbitMQBroker(
+                executor, amqp_url="amqp://guest:guest@localhost/",
+            ) as broker:
+                print(await asyncio.gather(
+                    *[
+                        broker.call("mul", i, i, timeout=1) for i in range(10)
+                     ]
+                ))
+
 
 `Propan`_:fire:
 ---------------
@@ -227,18 +324,111 @@ If you need no deep dive into **RabbitMQ** details, you can use more high-level 
 
 .. code-block:: python
 
-   from propane import Propaneapp, RabbitBroker
+   from propan import PropanApp, RabbitBroker
    
    broker = RabbitBroker("amqp://guest:guest@localhost:5672/")
-   app = Propane app(broker)
+   app = PropanApp(broker)
    
    @broker.handle("user")
    async def user_created(user_id: int):
        assert isinstance(user_id, int)
+       return f"user-{user_id}: created"
+
+   @app.after_startup
+   async def pub_smth():
+       assert (
+           await broker.publish(1, "user", callback=True)
+       ) ==  "user-1: created"
 
 Also, **Propan** validates messages by **pydantic**, generates your project **AsyncAPI** spec, tests application locally, RPC calls, and more.
 
 In fact, it is a high-level wrapper on top of **aio-pika**, so you can use both of these libraries' advantages at the same time.
+
+`python-socketio`_
+------------------
+
+`Socket.IO`_ is a transport protocol that enables real-time bidirectional event-based communication between clients (typically, though not always, web browsers) and a server. This package provides Python implementations of both, each with standard and asyncio variants.
+
+Also this package is suitable for building messaging services over **RabbitMQ** via **aio-pika** adapter:
+
+.. code-block:: python
+
+   import socketio
+   from aiohttp import web
+   
+   sio = socketio.AsyncServer(client_manager=socketio.AsyncAioPikaManager())
+   app = web.Application()
+   sio.attach(app)
+   
+   @sio.event
+   async def chat_message(sid, data):
+       print("message ", data)
+   
+   if __name__ == '__main__':
+       web.run_app(app)
+
+And a client is able to call `chat_message` the following way:
+
+.. code-block:: python
+
+   import asyncio
+   import socketio
+   
+   sio = socketio.AsyncClient()
+   
+   async def main():
+       await sio.connect('http://localhost:8080')
+       await sio.emit('chat_message', {'response': 'my response'})
+   
+   if __name__ == '__main__':
+       asyncio.run(main())
+
+The `taskiq`_ and the `taskiq-aio-pika`_
+----------------------------------------
+
+**Taskiq** is an asynchronous distributed task queue for python. The project takes inspiration from big projects such as Celery and Dramatiq. But taskiq can send and run both the sync and async functions.
+
+The library provides you with **aio-pika** broker for running tasks too.
+
+.. code-block:: python
+
+   from taskiq_aio_pika import AioPikaBroker
+   
+   broker = AioPikaBroker()
+   
+   @broker.task
+   async def test() -> None:
+       print("nothing")
+
+   async def main():
+       await broker.startup()
+       await test.kiq()
+
+`Rasa`_
+-------
+
+With over 25 million downloads, Rasa Open Source is the most popular open source framework for building chat and voice-based AI assistants.
+
+With **Rasa**, you can build contextual assistants on:
+
+* Facebook Messenger
+* Slack
+* Google Hangouts
+* Webex Teams
+* Microsoft Bot Framework
+* Rocket.Chat
+* Mattermost
+* Telegram
+* Twilio
+
+Your own custom conversational channels or voice assistants as:
+
+* Alexa Skills
+* Google Home Actions
+
+**Rasa** helps you build contextual assistants capable of having layered conversations with lots of back-and-forth. In order for a human to have a meaningful exchange with a contextual assistant, the assistant needs to be able to use context to build on things that were previously discussed – **Rasa** enables you to build assistants that can do this in a scalable way.
+
+And it also uses **aio-pika** to interact with **RabbitMQ** deep inside!
 
 Versioning
 ==========
@@ -249,4 +439,9 @@ This software follows `Semantic Versioning`_
 .. _Semantic Versioning: http://semver.org/
 .. _propan: https://github.com/Lancetnik/Propan
 .. _patio: https://github.com/patio-python/patio
-.. _patio-rmq: https://github.com/patio-python/patio-rabbitmq
+.. _patio-rabbitmq: https://github.com/patio-python/patio-rabbitmq
+.. _Socket.IO: https://socket.io/
+.. _python-socketio: https://python-socketio.readthedocs.io/en/latest/intro.html
+.. _taskiq: https://github.com/taskiq-python/taskiq
+.. _taskiq-aio-pika: https://github.com/taskiq-python/taskiq-aio-pika
+.. _Rasa: https://rasa.com/docs/rasa/


### PR DESCRIPTION
This is a raw exmaple of `See also` section what we talking about.

I had try to find some more examples and did it:
[Mela](https://github.com/uthunderbird/mela) - another one **aio-pika** wrapper, but maintainer looks like end of enthusiasm (so, I invite it to Propan collaborator and waiting for answer)
[aiormq](https://github.com/Polyconseil/aioamqp) - more **aiormq** alternative, whatever, it looks abandoned
[aiormq](https://github.com/mosquito/aiormq) - **aio-pika** core (you know), it can make sense to notice it here
[pika](https://pika.readthedocs.io/en/stable/modules/adapters/asyncio.html) - the official **RMQ** library, has an *asyncio* interface too. But it is implemented in some weird way, so I don't know what we should do with it.

Feel free to point me at any required changes.