### PR TITLE
Fix race condition in RobustChannel in reopen/ready

### DIFF
--- a/tests/test_amqp_robust.py
+++ b/tests/test_amqp_robust.py
@@ -3,6 +3,7 @@ from functools import partial
 
 import pytest
 from aiormq import ChannelNotFoundEntity
+from aiormq.exceptions import ChannelPreconditionFailed
 
 import aio_pika
 from aio_pika import RobustChannel
@@ -82,6 +83,28 @@ class TestCaseNoRobust(TestCaseAmqp):
 
         await asyncio.wait_for(reopen_event.wait(), timeout=60)
         await channel.declare_queue(queue_name, auto_delete=True)
+
+    async def test_get_queue_fail(self, connection):
+        channel: RobustChannel = await connection.channel()     # type: ignore
+        close_event = asyncio.Event()
+        reopen_event = asyncio.Event()
+        channel.close_callbacks.add(lambda *_: close_event.set())
+        channel.reopen_callbacks.add(lambda *_: reopen_event.set())
+
+        name = get_random_name("passive", "queue")
+
+        await channel.declare_queue(
+            name,
+            auto_delete=True,
+            arguments={"x-max-length": 1}
+        )
+        with pytest.raises(ChannelPreconditionFailed):
+            await channel.declare_queue(name, auto_delete=True)
+        await asyncio.sleep(0)
+        await close_event.wait()
+        await reopen_event.wait()
+        with pytest.raises(ChannelPreconditionFailed):
+            await channel.declare_queue(name, auto_delete=True)
 
 
 class TestCaseAmqpNoConfirmsRobust(TestCaseAmqpNoConfirms):


### PR DESCRIPTION
@mosquito Here's a test that repro the infinite loop hang and a fix.

The last `declare_queue` is where the hang happen.

(See #565 )