### PR TITLE
Update receive_logs_topic.py

### DIFF
--- a/docs/source/rabbitmq-tutorial/examples/5-topics/receive_logs_topic.py
+++ b/docs/source/rabbitmq-tutorial/examples/5-topics/receive_logs_topic.py
@@ -18,10 +18,10 @@ async def main() -> None:
         "topic_logs", ExchangeType.TOPIC,
     )
 
+    # Generate a unique queue name for this instance
+    unique_queue_name = f"name_{uuid.uuid4().hex}"
     # Declaring queue
-    queue = await channel.declare_queue(
-        "task_queue", durable=True,
-    )
+    queue = await channel.declare_queue(unique_queue_name, durable=True)
 
     binding_keys = sys.argv[1:]
 


### PR DESCRIPTION
Title: Issue with Shared Queue Across Multiple Subscribers

Description:

Hello Maintainers,

While using the library, I encountered an unexpected behaviour when running multiple subscriber instances with a shared queue. Specifically, when publishing a single message, only one of the subscribers receives it, even though all subscribers have similar bindings. After running the publisher multiple times, each subscriber eventually receives the message, suggesting a round-robin distribution due to the shared queue.

Steps to Reproduce:

Set up three subscriber instances with the following binding keys: "#", "kern.*", and "*.critical".
Run a publisher to send a message with the routing key "app.info".
Observe that only one subscriber receives the message. Running the publisher multiple times results in each subscriber eventually receiving the message.
Expected Behavior:
All subscribers with matching binding keys should receive the message on the first publish.

Actual Behavior:
Only one subscriber receives the message at a time due to the shared queue.

Proposed Solution:
After some investigation, I found that giving each subscriber instance its own unique queue (by setting `exclusive=True` during queue declaration and removing the queue name `task_queue`) resolved the issue. I've attached the modified code in this PR for reference. The code generates a new queue that is persistent as intended earlier for each instance of the script.

Would appreciate any feedback or insights into whether this is the intended behavior, and if the proposed solution aligns with the library's design principles.

Thank you for your time and consideration!