### PR TITLE
Define empty __slots__ in base classes

### DIFF
--- a/aio_pika/abc.py
+++ b/aio_pika/abc.py
@@ -140,6 +140,8 @@ class MessageInfo(TypedDict, total=False):
 
 
 class AbstractMessage(ABC):
+    __slots__ = ()
+
     body: bytes
     body_size: int
     headers: HeadersType
@@ -183,6 +185,8 @@ class AbstractMessage(ABC):
 
 
 class AbstractIncomingMessage(AbstractMessage, ABC):
+    __slots__ = ()
+
     cluster_id: Optional[str]
     consumer_tag: Optional["ConsumerTag"]
     delivery_tag: Optional[int]

--- a/aio_pika/abc.py
+++ b/aio_pika/abc.py
@@ -246,6 +246,8 @@ class AbstractProcessContext(AsyncContextManager):
 
 
 class AbstractQueue:
+    __slots__ = ()
+
     channel: "AbstractChannel"
     name: str
     durable: bool
@@ -779,6 +781,8 @@ class AbstractConnection(PoolInstance, ABC):
 
 
 class AbstractRobustQueue(AbstractQueue):
+    __slots__ = ()
+
     @abstractmethod
     def restore(self) -> Awaitable[None]:
         raise NotImplementedError

--- a/aio_pika/patterns/base.py
+++ b/aio_pika/patterns/base.py
@@ -34,6 +34,8 @@ class Proxy:
 
 
 class Base:
+    __slots__ = ()
+
     SERIALIZER = pickle
     CONTENT_TYPE = "application/python-pickle"
 

--- a/aio_pika/patterns/master.py
+++ b/aio_pika/patterns/master.py
@@ -67,6 +67,8 @@ class Master(Base):
         "channel",
         "loop",
         "proxy",
+        "_requeue",
+        "_reject_on_redelivered",
     )
 
     DELIVERY_MODE = DeliveryMode.PERSISTENT

--- a/aio_pika/patterns/rpc.py
+++ b/aio_pika/patterns/rpc.py
@@ -44,11 +44,15 @@ class RPC(Base):
         "channel",
         "loop",
         "proxy",
+        "futures",
         "result_queue",
         "result_consumer_tag",
         "routes",
+        "queues",
         "consumer_tags",
         "dlx_exchange",
+        "rpc_exchange",
+        "host_exceptions",
     )
 
     DLX_NAME = "rpc.dlx"

--- a/aio_pika/queue.py
+++ b/aio_pika/queue.py
@@ -40,6 +40,20 @@ async def consumer(
 class Queue(AbstractQueue):
     """ AMQP queue abstraction """
 
+    __slots__ = (
+        "__weakref__",
+        "__get_lock",
+        "close_callbacks",
+        "channel",
+        "name",
+        "durable",
+        "exclusive",
+        "auto_delete",
+        "arguments",
+        "passive",
+        "declaration_result",
+    )
+
     def __init__(
         self,
         channel: AbstractChannel,


### PR DESCRIPTION
I've noticed that `__slots__` are defined in `Message`-classes, but they were not working as expected.

> When inheriting from a class without __slots__, the __dict__ and __weakref__ attribute of the instances will always be accessible.

https://docs.python.org/3/reference/datamodel.html?#object.__slots__

So all parent classes must also have `__slots__` to disable `__dict__` creation. That's what I did in this PR