### PR TITLE
Add channel definition code to example in rabbitmq-tutorial/1-introduction.rst

### DIFF
--- a/docs/source/rabbitmq-tutorial/1-introduction.rst
+++ b/docs/source/rabbitmq-tutorial/1-introduction.rst
@@ -123,7 +123,7 @@ thing we need to do is to establish a connection with RabbitMQ server.
 
 .. literalinclude:: examples/1-introduction/send.py
    :language: python
-   :lines: 5-8
+   :lines: 5-12
 
 We're connected now, to a broker on the local machine - hence the localhost.
 If we wanted to connect to a broker on a different machine we'd simply specify


### PR DESCRIPTION
To sync aio-pika's tutorial example with official tutorial's example