### PR TITLE
fix: typo from somple to simple

### DIFF
--- a/docs/source/rabbitmq-tutorial/4-routing.rst
+++ b/docs/source/rabbitmq-tutorial/4-routing.rst
@@ -180,7 +180,7 @@ Putting it all together
 .. image:: /_static/tutorial/python-four.svg
    :align: center
 
-The simplified code for :download:`receive_logs_direct_somple.py <examples/4-routing/receive_logs_direct_simple.py>`:
+The simplified code for :download:`receive_logs_direct_simple.py <examples/4-routing/receive_logs_direct_simple.py>`:
 
 .. literalinclude:: examples/4-routing/receive_logs_direct_simple.py
    :language: python


### PR DESCRIPTION
on the [page](https://aio-pika.readthedocs.io/en/latest/rabbitmq-tutorial/4-routing.html#) while i was reading the doc.
I found this typo  **Somple** which bothers me.