### PR TITLE
fix: raise ChannelInvalidStateError at exchange.publish with closed channel

### DIFF
--- a/aio_pika/exchange.py
+++ b/aio_pika/exchange.py
@@ -191,7 +191,9 @@ class Exchange(AbstractExchange):
             )
 
         if self.channel.is_closed:
-            raise aiormq.exceptions.ChannelInvalidStateError("%r closed" % self.channel)
+            raise aiormq.exceptions.ChannelInvalidStateError(
+                "%r closed" % self.channel,
+            )
 
         channel = await self.channel.get_underlay_channel()
         return await channel.basic_publish(

--- a/aio_pika/exchange.py
+++ b/aio_pika/exchange.py
@@ -190,6 +190,9 @@ class Exchange(AbstractExchange):
                 f"Can not publish to internal exchange: '{self.name}'!",
             )
 
+        if self.channel.is_closed:
+            raise aiormq.exceptions.ChannelInvalidStateError("%r closed" % self.channel)
+
         channel = await self.channel.get_underlay_channel()
         return await channel.basic_publish(
             exchange=self.name,

--- a/tests/test_amqp.py
+++ b/tests/test_amqp.py
@@ -359,7 +359,11 @@ class TestCaseAmqp(TestCaseAmqpBase):
 
         with pytest.raises(aiormq.exceptions.ChannelInvalidStateError):
             await exchange.publish(
-                Message(body, content_type="text/plain", headers={"foo": "bar"}),
+                Message(
+                    body,
+                    content_type="text/plain",
+                    headers={"foo": "bar"},
+                ),
                 routing_key,
             )
 


### PR DESCRIPTION
Close #636, close #556, close https://github.com/airtai/faststream/issues/1579

Exception was copied from https://github.com/mosquito/aiormq/blob/master/aiormq/channel.py#L145