### PR TITLE
fix: RobustChannel should not reopen after close() call

### DIFF
--- a/aio_pika/robust_channel.py
+++ b/aio_pika/robust_channel.py
@@ -121,6 +121,14 @@ class RobustChannel(Channel, AbstractRobustChannel):    # type: ignore
 
         return exc
 
+    async def close(
+        self,
+        exc: Optional[aiormq.abc.ExceptionType] = None,
+    ) -> None:
+        # Avoid recovery when channel is explicitely closed using this method
+        self.__restored.clear()
+        await super().close(exc)
+
     async def reopen(self) -> None:
         await super().reopen()
         await self.reopen_callbacks()

--- a/tests/test_amqp_robust.py
+++ b/tests/test_amqp_robust.py
@@ -110,8 +110,24 @@ class TestCaseNoRobust(TestCaseAmqp):
         channel: RobustChannel = await connection.channel()  # type: ignore
         await channel.ready()
         await channel.close()
+        assert channel.is_closed is True
+
         await channel.reopen()
         await asyncio.wait_for(channel.ready(), timeout=1)
+
+        assert channel.is_closed is False
+
+    async def test_channel_can_be_closed(self, connection):
+        channel: RobustChannel = await connection.channel()  # type: ignore
+        await channel.ready()
+        await channel.close()
+
+        assert channel.is_closed
+
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(channel.ready(), timeout=1)
+
+        assert channel.is_closed
 
 
 class TestCaseAmqpNoConfirmsRobust(TestCaseAmqpNoConfirms):


### PR DESCRIPTION
It's not possible to close the RobustChannel right now, it always reopens.