### PR TITLE
Add missing message ack to example (docs)

### DIFF
--- a/docs/source/rabbitmq-tutorial/examples/2-work-queues/tasks_worker.py
+++ b/docs/source/rabbitmq-tutorial/examples/2-work-queues/tasks_worker.py
@@ -9,6 +9,8 @@ async def on_message(message: AbstractIncomingMessage) -> None:
         print(f" [x] Received message {message!r}")
         await asyncio.sleep(message.body.count(b'.'))
         print(f"     Message body is: {message.body!r}")
+        # Consumer acknowledging the message
+        message.ack()
 
 
 async def main() -> None:


### PR DESCRIPTION
**Description**:
This pull request addresses a missing message acknowledgment in the "Work Queues" example from the documentation.

### Summary of Changes:
- In the "Putting it all together" section, the example consumer was missing the necessary acknowledgment (`message.ack()`) after processing the message.
- The page has a Message Acknowledgement section, so I thought the example should contain the `message.ack()` statement.
  
### Changes Made:
- Added `await message.ack()` to the consumer's message processing loop to ensure proper message acknowledgment.

By adding this acknowledgment, the example now aligns with all the sections on the page.
