### PR TITLE
Replace WeakSet with set for robust channels tracking

### DIFF
--- a/aio_pika/robust_channel.py
+++ b/aio_pika/robust_channel.py
@@ -2,9 +2,8 @@ import asyncio
 import warnings
 from collections import defaultdict
 from itertools import chain
-from typing import Any, DefaultDict, Dict, MutableSet, Optional, Type, Union
+from typing import Any, DefaultDict, Dict, Optional, Set, Type, Union
 from warnings import warn
-from weakref import WeakSet
 
 import aiormq
 
@@ -32,8 +31,8 @@ class RobustChannel(Channel, AbstractRobustChannel):    # type: ignore
 
     RESTORE_RETRY_DELAY: int = 2
 
-    _exchanges: DefaultDict[str, MutableSet[AbstractRobustExchange]]
-    _queues: DefaultDict[str, MutableSet[RobustQueue]]
+    _exchanges: DefaultDict[str, Set[AbstractRobustExchange]]
+    _queues: DefaultDict[str, Set[RobustQueue]]
     default_exchange: RobustExchange
 
     def __init__(
@@ -61,8 +60,8 @@ class RobustChannel(Channel, AbstractRobustChannel):    # type: ignore
             on_return_raises=on_return_raises,
         )
 
-        self._exchanges = defaultdict(WeakSet)
-        self._queues = defaultdict(WeakSet)
+        self._exchanges = defaultdict(set)
+        self._queues = defaultdict(set)
         self._prefetch_count: int = 0
         self._prefetch_size: int = 0
         self._global_qos: bool = False
@@ -194,6 +193,11 @@ class RobustChannel(Channel, AbstractRobustChannel):    # type: ignore
         timeout: TimeoutType = None,
         robust: bool = True,
     ) -> AbstractRobustExchange:
+        """
+        :param robust: If True, the exchange will be re-declared during
+        reconnection.
+        Set to False for temporary exchanges that should not be restored.
+        """
         await self.ready()
         exchange = (
             await super().declare_exchange(
@@ -243,6 +247,11 @@ class RobustChannel(Channel, AbstractRobustChannel):    # type: ignore
         timeout: TimeoutType = None,
         robust: bool = True,
     ) -> AbstractRobustQueue:
+        """
+        :param robust: If True, the queue will be re-declared during
+        reconnection.
+        Set to False for temporary queues that should not be restored.
+        """
         await self.ready()
         queue: RobustQueue = await super().declare_queue(   # type: ignore
             name=name,


### PR DESCRIPTION
# Replace WeakSet with set for robust channels tracking

## Problem

Currently, `RobustChannel` uses `WeakSet` to track exchanges and queues for reconnection. This causes issues when the connection is lost, as the references to queues and exchanges may be garbage collected if there are no other references to them in the user's code. When the connection is restored, these objects aren't automatically recreated.

## Solution

This PR changes the collections from `WeakSet` to regular `set` to ensure that all exchanges and queues created with `robust=True` are properly restored after reconnection, regardless of whether there are other references to them.

## Changes

1. Replace `defaultdict(WeakSet)` with `defaultdict(set)` for both exchanges and queues
2. Update docstrings to clarify the behavior of the `robust` parameter

## Impact

- **Positive**: Exchanges and queues will be properly restored after reconnection
- **Note**: Users who don't want exchanges/queues to be restored must now explicitly set `robust=False`, or manually delete them when they're no longer needed

## Usage Guidance for Users

For temporary exchanges or queues that should not be restored on reconnection, users should now explicitly set `robust=False` when declaring them:

```python
# Temporary queue that won't be restored on reconnection
temp_queue = await channel.declare_queue(robust=False)

# Temporary exchange that won't be restored on reconnection
temp_exchange = await channel.declare_exchange("temp_exchange", robust=False)
```

Otherwise, make sure to properly delete exchanges and queues when they're no longer needed to avoid memory leaks:

```python
# When no longer needed
await channel.queue_delete(queue.name)
await channel.exchange_delete(exchange.name)
```