### PR TITLE
Catch and log potential exception during the OneShotCallback task execution

### DIFF
--- a/aio_pika/tools.py
+++ b/aio_pika/tools.py
@@ -304,6 +304,8 @@ class OneShotCallback:
 
             try:
                 await self.callback(*args, **kwargs)
+            except Exception:
+                log.exception("Callback %r error", self)
             finally:
                 self.loop.call_soon(self.finished.set)
                 del self.callback


### PR DESCRIPTION
Since `__task_inner()` is spawned as an `asyncio.Task` using the `channel.closing.add_done_callback()`, the only place where it can be awaited for potential exceptions is under `UnderlayChannel.close()`. This is done by calling the `OneShotCallback.wait()` method. However, when the connection to RabbitMQ is severed, the callback call inside the `OneShotCallback` task can raise an error when trying to reopen the connection, and when this happens, the channel instance is replaced with a new channel, which has a new instance of `OneShotCallback`.

Because of this, the original `OneShotCallback` task is never awaited in the `UnderlayChannel.close()`. So, to properly check for potential exceptions in the original task, we would need to await it somewhere or call the `self.__task.exception()` value. This never happens, which produces an error from the asyncio library: `Task exception was never retrieved`.

To solve this, we will now catch and log that potential error during the `OneShotCallback` task execution which means that we never have to await this task or call `self.__task.exception()` to retrieve the exception.

### Reproduction:

1. Run the RabbitMQ docker

```
docker run --rm --hostname localhost -p '5672:5672' --name rabbitmq rabbitmq:3
```

2. Execute the following script

```python
import asyncio
import aio_pika

async def main():
    connection = await aio_pika.connect_robust(
        host="localhost",
        port=5672,
        heartbeat=5,
        login="guest",
        password="guest",
    )

    channel: aio_pika.abc.AbstractChannel = await connection.channel(publisher_confirms=True)

    try:
        while True:
            await asyncio.sleep(1)
    finally:
        await channel.close()
        await connection.close()


if __name__ == "__main__":
    try:
        asyncio.run(main())
    except KeyboardInterrupt:
        pass
```

3. Kill the RabbitMQ docker:

```
docker kill rabbitmq
```

4. Run the RabbitMQ docker again

```
docker run --rm --hostname localhost -p '5672:5672' --name rabbitmq rabbitmq:3
```

5. Wait for the script to reconnect to RabbitMQ
6. Kill the script via Ctrl+C

#### Before this change (`Task exception was never retrieved` present):

```
Connection attempt to "amqp://guest:******@localhost:5672//?heartbeat=5" failed: Multiple exceptions: [Errno 61] Connect call failed ('::1', 5672, 0, 0), [Errno 61] Connect call failed ('127.0.0.1', 5672). Reconnecting after 5 seconds.
Connection attempt to "amqp://guest:******@localhost:5672//?heartbeat=5" failed: Server connection reset: ConnectionResetError(54, 'Connection reset by peer'). Reconnecting after 5 seconds.
Connection attempt to "amqp://guest:******@localhost:5672//?heartbeat=5" failed: Server connection reset: ConnectionResetError(54, 'Connection reset by peer'). Reconnecting after 5 seconds.
Connection attempt to "amqp://guest:******@localhost:5672//?heartbeat=5" failed: Server connection reset: ConnectionResetError(54, 'Connection reset by peer'). Reconnecting after 5 seconds.
^C
Task exception was never retrieved
future: <Task finished name='Task-19' coro=<OneShotCallback.__task_inner() done, defined at /Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aio_pika/tools.py:304> exception=RuntimeError('<Connection: "amqp://guest:******@localhost:5672//?heartbeat=5" at 0x105cc8dc0> closed')>
Traceback (most recent call last):
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aio_pika/tools.py", line 310, in __task_inner
    await self.callback(*args, **kwargs)
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aio_pika/robust_channel.py", line 119, in _on_close
    await self.restore()
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aio_pika/robust_channel.py", line 94, in restore
    await self.reopen()
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aio_pika/robust_channel.py", line 132, in reopen
    await super().reopen()
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aio_pika/channel.py", line 244, in reopen
    await self._open()
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aio_pika/channel.py", line 173, in _open
    channel = await UnderlayChannel.create(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aio_pika/abc.py", line 485, in create
    channel = await connection.channel(**kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aiormq/connection.py", line 830, in channel
    raise RuntimeError("%r closed" % self)
RuntimeError: <Connection: "amqp://guest:******@localhost:5672//?heartbeat=5" at 0x105cc8dc0> closed
```

#### After this change (`Task exception was never retrieved` not present):

```
Callback <OneShotCallback: cb=<bound method RobustChannel._on_close of <aio_pika.robust_channel.RobustChannel object at 0x103ace4e0>>> error
Traceback (most recent call last):
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aio_pika/tools.py", line 310, in __task_inner
    await self.callback(*args, **kwargs)
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aio_pika/robust_channel.py", line 119, in _on_close
    await self.restore()
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aio_pika/robust_channel.py", line 94, in restore
    await self.reopen()
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aio_pika/robust_channel.py", line 132, in reopen
    await super().reopen()
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aio_pika/channel.py", line 244, in reopen
    await self._open()
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aio_pika/channel.py", line 173, in _open
    channel = await UnderlayChannel.create(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aio_pika/abc.py", line 485, in create
    channel = await connection.channel(**kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/krzysztof.przybyla/.pyenv/versions/aio-pika-env/lib/python3.12/site-packages/aiormq/connection.py", line 830, in channel
    raise RuntimeError("%r closed" % self)
RuntimeError: <Connection: "amqp://guest:******@localhost:5672//?heartbeat=5" at 0x103eb8f50> closed
Connection attempt to "amqp://guest:******@localhost:5672//?heartbeat=5" failed: Multiple exceptions: [Errno 61] Connect call failed ('::1', 5672, 0, 0), [Errno 61] Connect call failed ('127.0.0.1', 5672). Reconnecting after 5 seconds.
Connection attempt to "amqp://guest:******@localhost:5672//?heartbeat=5" failed: Server connection reset: ConnectionResetError(54, 'Connection reset by peer'). Reconnecting after 5 seconds.
Connection attempt to "amqp://guest:******@localhost:5672//?heartbeat=5" failed: Server connection reset: ConnectionResetError(54, 'Connection reset by peer'). Reconnecting after 5 seconds.
^C
```