### PR TITLE
Split log.exception calls into an error and a debug

### DIFF
--- a/aio_pika/patterns/rpc.py
+++ b/aio_pika/patterns/rpc.py
@@ -326,8 +326,17 @@ class RPC(Base):
             await self.channel.default_exchange.publish(
                 result_message, message.reply_to, mandatory=False,
             )
-        except Exception:
-            log.exception("Failed to send reply %r", result_message)
+        except Exception as exc:
+            log.error(
+                "Failed to send reply %r due to %s: %s",
+                result_message,
+                type(exc).__name__,
+                exc,
+            )
+            log.debug(
+                "Full traceback for failure to send reply %r",
+                exc_info=True,
+            )
             await message.reject(requeue=False)
             return
 

--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -100,8 +100,16 @@ class RobustConnection(Connection, AbstractRobustConnection):
             for channel in tuple(self.__channels):
                 try:
                     await channel.restore()
-                except Exception:
-                    log.exception("Failed to reopen channel")
+                except Exception as exc:
+                    log.error(
+                        "Failed to reopen channel due to %s: %s",
+                        type(exc).__name__,
+                        exc,
+                    )
+                    log.debug(
+                        "Full traceback for failure to reopen channel",
+                        exc_info=True,
+                    )
                     raise
         except Exception as e:
             await self.close_callbacks(e)
@@ -148,11 +156,18 @@ class RobustConnection(Connection, AbstractRobustConnection):
                     "Reconnecting after %r seconds.",
                     self, e, self.reconnect_interval,
                 )
-            except Exception:
-                log.exception(
-                    "Reconnect attempt failed %s. "
+            except Exception as exc:
+                log.error(
+                    "Reconnect attempt failed %s due to %s: %s. "
                     "Retrying after %r seconds.",
-                    self, self.reconnect_interval,
+                    self,
+                    type(exc).__name__,
+                    exc,
+                    self.reconnect_interval,
+                )
+                log.debug(
+                    "Full traceback for reconnect failure",
+                    exc_info=True,
                 )
 
             await asyncio.sleep(self.reconnect_interval)

--- a/aio_pika/tools.py
+++ b/aio_pika/tools.py
@@ -264,8 +264,18 @@ class CallbackCollection(
                         result = cb(sender, *args, **kwargs)
                     if inspect.isawaitable(result):
                         futures.append(asyncio.ensure_future(result))
-                except Exception:
-                    log.exception("Callback %r error", cb)
+                except Exception as exc:
+                    log.error(
+                        "Callback %r error: %s: %s",
+                        cb,
+                        type(exc).__name__,
+                        exc,
+                    )
+                    log.debug(
+                        "Full traceback for callback %r error",
+                        cb,
+                        exc_info=True,
+                    )
 
         if not futures:
             return STUB_AWAITABLE
@@ -304,8 +314,18 @@ class OneShotCallback:
 
             try:
                 await self.callback(*args, **kwargs)
-            except Exception:
-                log.exception("Callback %r error", self)
+            except Exception as exc:
+                log.error(
+                    "Callback %r error: %s: %s",
+                    self,
+                    type(exc).__name__,
+                    exc,
+                )
+                log.debug(
+                    "Full traceback for callback %r error",
+                    self,
+                    exc_info=True,
+                )
             finally:
                 self.loop.call_soon(self.finished.set)
                 del self.callback


### PR DESCRIPTION
The error log now contains the exception name and str explicitly, and the traceback is moved to the added debug.

In my experience, the traceback in these cases is usually long not particularly helpful, but I do think it's worth keeping in a debug message for those who need it.
