### PR TITLE
fix: use TypeVar for connect and connect_robust return types

### DIFF
--- a/aio_pika/connection.py
+++ b/aio_pika/connection.py
@@ -12,6 +12,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    overload,
 )
 
 
@@ -36,6 +37,7 @@ from .tools import CallbackCollection
 
 log = get_logger(__name__)
 T = TypeVar("T")
+ConnectionType = TypeVar("ConnectionType", bound=AbstractConnection)
 
 
 class Connection(AbstractConnection):
@@ -300,6 +302,43 @@ def make_url(
         path="/" + virtualhost,
         query=kw,
     )
+
+
+@overload
+async def connect(
+    url: Union[str, URL, None] = None,
+    *,
+    host: str = "localhost",
+    port: int = 5672,
+    login: str = "guest",
+    password: str = "guest",
+    virtualhost: str = "/",
+    ssl: bool = False,
+    loop: Optional[asyncio.AbstractEventLoop] = None,
+    ssl_options: Optional[SSLOptions] = None,
+    ssl_context: Optional[SSLContext] = None,
+    timeout: TimeoutType = None,
+    client_properties: Optional[FieldTable] = None,
+) -> Connection: ...
+
+
+@overload
+async def connect(
+    url: Union[str, URL, None] = None,
+    *,
+    host: str = "localhost",
+    port: int = 5672,
+    login: str = "guest",
+    password: str = "guest",
+    virtualhost: str = "/",
+    ssl: bool = False,
+    loop: Optional[asyncio.AbstractEventLoop] = None,
+    ssl_options: Optional[SSLOptions] = None,
+    ssl_context: Optional[SSLContext] = None,
+    timeout: TimeoutType = None,
+    client_properties: Optional[FieldTable] = None,
+    connection_class: Type[ConnectionType] = ...,
+) -> ConnectionType: ...
 
 
 async def connect(

--- a/aio_pika/robust_connection.py
+++ b/aio_pika/robust_connection.py
@@ -1,6 +1,6 @@
 import asyncio
 from ssl import SSLContext
-from typing import Any, Optional, Tuple, Type, Union
+from typing import Any, Optional, Tuple, Type, TypeVar, Union, overload
 from weakref import WeakSet
 
 import aiormq.abc
@@ -21,6 +21,11 @@ from .log import get_logger
 from .robust_channel import RobustChannel
 from .tools import CallbackCollection
 
+
+RobustConnectionType = TypeVar(
+    "RobustConnectionType",
+    bound=AbstractRobustConnection,
+)
 
 log = get_logger(__name__)
 
@@ -256,6 +261,43 @@ class RobustConnection(Connection, AbstractRobustConnection):
             self.__reconnection_task = None
 
         return await super().close(exc)
+
+
+@overload
+async def connect_robust(
+    url: Union[str, URL, None] = None,
+    *,
+    host: str = "localhost",
+    port: int = 5672,
+    login: str = "guest",
+    password: str = "guest",
+    virtualhost: str = "/",
+    ssl: bool = False,
+    loop: Optional[asyncio.AbstractEventLoop] = None,
+    ssl_options: Optional[SSLOptions] = None,
+    ssl_context: Optional[SSLContext] = None,
+    timeout: TimeoutType = None,
+    client_properties: Optional[FieldTable] = None,
+) -> RobustConnection: ...
+
+
+@overload
+async def connect_robust(
+    url: Union[str, URL, None] = None,
+    *,
+    host: str = "localhost",
+    port: int = 5672,
+    login: str = "guest",
+    password: str = "guest",
+    virtualhost: str = "/",
+    ssl: bool = False,
+    loop: Optional[asyncio.AbstractEventLoop] = None,
+    ssl_options: Optional[SSLOptions] = None,
+    ssl_context: Optional[SSLContext] = None,
+    timeout: TimeoutType = None,
+    client_properties: Optional[FieldTable] = None,
+    connection_class: Type[RobustConnectionType] = ...,
+) -> RobustConnectionType: ...
 
 
 async def connect_robust(


### PR DESCRIPTION
## Summary

- Use `TypeVar` bound to `AbstractConnection` / `AbstractRobustConnection` for the `connection_class` parameter and return type of `connect()` and `connect_robust()`
- This allows mypy to correctly infer the return type when a concrete `connection_class` is provided (e.g., `aio_pika.RobustConnection`)

Closes #683

## Test plan

- [ ] Verify `mypy` no longer reports type mismatch when annotating the result of `connect_robust(connection_class=RobustConnection)` as `RobustConnection`
- [ ] Verify default calls (without `connection_class`) still type-check correctly
- [ ] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)